### PR TITLE
Don't b0rk on ldap

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -221,11 +221,11 @@ class Application @Inject() (val cc:ControllerComponents,
   }
 
   def healthcheck = Action.async { request=>
-    val checkFutures = Future.sequence(Seq(LDAP.hasConnectionPool,dbHelper.healthcheck))
+    val checkFutures = Future.sequence(Seq(dbHelper.healthcheck))
 
     checkFutures.map(resultSeq=>{
-      val ldapCheck = resultSeq.head
-      val dbCheck = resultSeq(1)
+      val ldapCheck = Success( () ) //dont b0rk on a failing ldap check
+      val dbCheck = resultSeq.head
       val ldapMode = config.getOptional[String]("ldap.ldapProtocol").getOrElse("ldap")
 
       if( (ldapMode!="none" && ldapCheck.isFailure) || dbCheck.isFailure){


### PR DESCRIPTION
## What does this change?

removes the ldap check from the healthcheck endpoint.  This is a temporary measure for the phase1 system.

## How to test

Fire up the system without valid ldap configuration. LDAP login will still fail but the healthcheck won't and so the system will stay up

## How can we measure success?

System stays up

## Have we considered potential risks?

Running the system without ldap means that pluto-helper-agent won't work.  But everything else should do.
