### PR TITLE
Remove Forwarding to pluto-start

### DIFF
--- a/frontend/app/index.jsx
+++ b/frontend/app/index.jsx
@@ -200,21 +200,6 @@ class App extends React.Component {
     this.setState({ currentUsername: "", isLoggedIn: false });
   }
 
-  componentDidUpdate(prevProps, prevState, snapshot) {
-    setTimeout(() => {
-      if (
-        this.state.haveChecked &&
-        !this.state.isLoggedIn &&
-        window.location.pathname !== "/"
-      ) {
-        console.log("Not logged in, redirecting to pluto-start.");
-        window.location.assign(
-          "/refreshLogin?returnTo=" + window.location.pathname
-        );
-      }
-    }, 3000);
-  }
-
   haveToken() {
     return window.localStorage.getItem("pluto:access-token");
   }


### PR DESCRIPTION
## What does this change?

Removes the forwarding code as it is not complatable with Azure.

## How can we measure success?

The software no longer attempts to forward the browser to pluto-start.

## Have we considered potential risks?

Yes. This is completely safe. The code was put in in one block, save it originally was set to timeout after one thousand milliseconds not three thousand. Removing it should do nothing apart from cause the software to stop forwarding to a currently broken URL.