### PR TITLE
Draft: Update project status when commission is updated

### DIFF
--- a/app/controllers/PlutoCommissionController.scala
+++ b/app/controllers/PlutoCommissionController.scala
@@ -233,7 +233,6 @@ class PlutoCommissionController @Inject()(projectEntryController: ProjectEntryCo
       validRecord => {
         val updateResult = this.dbupdate(id, validRecord)
         updateResult.flatMap { rowsUpdated =>
-          if (validRecord.status != EntryStatus.Held) { // check status before updating project status
             projectEntryController.updateStatusByCommissionId(Some(id), validRecord.status).map { statusUpdateRows =>
               if (statusUpdateRows >= 0) {
                 Ok(Json.obj("status" -> "ok", "detail" -> "Record and associated projects updated", "id" -> id))
@@ -243,9 +242,6 @@ class PlutoCommissionController @Inject()(projectEntryController: ProjectEntryCo
             }.recover {
               case ex: Exception => InternalServerError(Json.obj("status" -> "error", "detail" -> ex.getMessage))
             }
-          } else {
-            Future.successful(Ok(Json.obj("status" -> "ok", "detail" -> "Record updated, but project status was not updated due to HELD status", "id" -> id)))
-          }
         }.recover {
           case ex: Exception => InternalServerError(Json.obj("status" -> "error", "detail" -> ex.getMessage))
         }

--- a/app/controllers/ProjectEntryController.scala
+++ b/app/controllers/ProjectEntryController.scala
@@ -71,10 +71,11 @@ class ProjectEntryController @Inject() (@Named("project-creation-actor") project
       val updateAction = dbConfig.db.run(query.map(_.status).update(status))
 
       // Then use map to chain the next operation, sending the messages to RabbitMQ
-      updateAction.map { _ =>
+      updateAction.map { rowsUpdated =>
         ids.foreach { id =>
           sendToRabbitMq(UpdateOperation(), id, rabbitMqPropagator)
         }
+        rowsUpdated
       }
     }
   }

--- a/app/controllers/ProjectEntryController.scala
+++ b/app/controllers/ProjectEntryController.scala
@@ -52,7 +52,6 @@ class ProjectEntryController @Inject() (@Named("project-creation-actor") project
     with Security
 {
 
-
   def updateStatusByCommissionId(commissionId: Option[Int], status: EntryStatus.Value) = {
     import EntryStatusMapper._
     val query = for {p <- TableQuery[ProjectEntryRow] if p.commission === commissionId && p.status =!= EntryStatus.Held && p.status =!= EntryStatus.Killed} yield p.status


### PR DESCRIPTION
## What does this change?

Projects that belong to a commission will have their status changed when the commission status is changed.
UNLESS: 

- The project status is HELD or KILLED in which case the status will remain untouched.
## How to test
Change the status of a commission in Pluto and see the associated projects update in line with the rules listed above.
Check that rabbitMq messages are created for the commission update and also each contained project update.

