### PR TITLE
Commission update 

### DIFF
--- a/app/controllers/PlutoCommissionController.scala
+++ b/app/controllers/PlutoCommissionController.scala
@@ -176,6 +176,7 @@ class PlutoCommissionController @Inject()(override val controllerComponents:Cont
 
       db.run(TableQuery[PlutoCommissionRow].filter(_.id===itemId).update(newRecord).asTry)
         .map(maybeRows=>{
+          commissionStatusPropagator ! CommissionStatusPropagator.CommissionStatusUpdate(itemId, newRecord.status)
           sendToRabbitMq(UpdateOperation(),newRecord,rabbitMqPropagator)
           maybeRows
         })

--- a/app/controllers/PlutoCommissionController.scala
+++ b/app/controllers/PlutoCommissionController.scala
@@ -2,25 +2,24 @@ package controllers
 
 import akka.actor.ActorRef
 import auth.BearerTokenAuth
-import exceptions.{AlreadyExistsException, BadDataException}
 import helpers.AllowCORSFunctions
-import javax.inject._
 import models._
 import play.api.Configuration
 import play.api.cache.SyncCacheApi
 import play.api.db.slick.DatabaseConfigProvider
-import play.api.http.{HttpEntity, Status}
+import play.api.http.HttpEntity
 import play.api.libs.json.{JsError, JsResult, JsValue, Json}
-import play.api.mvc.{ControllerComponents, EssentialAction, Request, ResponseHeader, Result}
+import play.api.mvc.{ControllerComponents, Request, ResponseHeader, Result}
 import services.{CommissionStatusPropagator, CreateOperation, UpdateOperation}
 import slick.jdbc.PostgresProfile
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.TableQuery
 
+import javax.inject._
 import scala.collection.immutable.ListMap
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
-import scala.concurrent.ExecutionContext.Implicits.global
 
 @Singleton
 class PlutoCommissionController @Inject()(override val controllerComponents:ControllerComponents,


### PR DESCRIPTION

## What does this change?

When a commission status is changed the status of associated projects changes according to these rules:
 
Commission “Completed” → all projects NOT Completed or Killed should be set to Completed
Commission “Held” → all projects NOT Completed or Killed or Held should be set to Held
Commission “In Progress” → no change
Commission "Killed" -> all projects NOT Completed or Killed should be set to Killed

## How to test

Change the status of a commission in Pluto and see the associated projects update in line with the rules listed above.
