### PR TITLE
Rp/version fix

### DIFF
--- a/app/controllers/PremiereVersionConverter.scala
+++ b/app/controllers/PremiereVersionConverter.scala
@@ -39,7 +39,7 @@ class PremiereVersionConverter @Inject()(override val controllerComponents:Contr
       case Some(newVersion)=>
         val resultFut = for {
           targetVersion <- premiereVersionTranslationDAO
-            .findDisplayedVersionByMajor(newVersion)
+            .findDisplayedVersionByMajor(newVersion.major)
             .flatMap(results=>{
               if(results.isEmpty) {
                 Future.failed(new RuntimeException("Version number is not recognised"))

--- a/app/controllers/PremiereVersionConverter.scala
+++ b/app/controllers/PremiereVersionConverter.scala
@@ -39,7 +39,7 @@ class PremiereVersionConverter @Inject()(override val controllerComponents:Contr
       case Some(newVersion)=>
         val resultFut = for {
           targetVersion <- premiereVersionTranslationDAO
-            .findDisplayedVersion(newVersion)
+            .findDisplayedVersionByMajor(newVersion)
             .flatMap(results=>{
               if(results.isEmpty) {
                 Future.failed(new RuntimeException("Version number is not recognised"))

--- a/app/controllers/PremiereVersionConverter.scala
+++ b/app/controllers/PremiereVersionConverter.scala
@@ -5,7 +5,7 @@ import akka.stream.scaladsl.{Keep, Sink}
 import auth.{BearerTokenAuth, Security}
 import helpers.PostrunDataCache
 import models.PremiereVersionTranslationCodec._
-import models._
+import models.{FileEntry, FileEntryDAO, PremiereVersionTranslation, ProjectEntry, StorageEntry, StorageEntryHelper}
 import play.api.Configuration
 import play.api.cache.SyncCacheApi
 import play.api.db.slick.DatabaseConfigProvider

--- a/app/controllers/PremiereVersionConverter.scala
+++ b/app/controllers/PremiereVersionConverter.scala
@@ -101,6 +101,7 @@ def lookupClientVersion(clientVersionString:String) = IsAuthenticatedAsync { uid
   }
 }
 
+
   def lookupInternalVersion(internalVersion:Int) = IsAuthenticatedAsync { uid=> request=>
     premiereVersionTranslationDAO
       .findInternalVersion(internalVersion)

--- a/app/controllers/PremiereVersionConverter.scala
+++ b/app/controllers/PremiereVersionConverter.scala
@@ -4,7 +4,8 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.{Keep, Sink}
 import auth.{BearerTokenAuth, Security}
 import helpers.PostrunDataCache
-import models.{DisplayedVersion, FileEntry, FileEntryDAO, FileEntrySerializer, PremiereVersionTranslation, PremiereVersionTranslationDAO, ProjectEntry}
+import models.PremiereVersionTranslationCodec._
+import models._
 import play.api.Configuration
 import play.api.cache.SyncCacheApi
 import play.api.db.slick.DatabaseConfigProvider
@@ -14,12 +15,9 @@ import postrun.{AdobeXml, ExtractPremiereVersion}
 import slick.jdbc.PostgresProfile
 
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success, Try}
-import models.PremiereVersionTranslationCodec._
-import services.NewProjectBackup
-
 import scala.annotation.switch
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
 
 @Singleton
 class PremiereVersionConverter @Inject()(override val controllerComponents:ControllerComponents,

--- a/app/controllers/PremiereVersionConverter.scala
+++ b/app/controllers/PremiereVersionConverter.scala
@@ -5,7 +5,7 @@ import akka.stream.scaladsl.{Keep, Sink}
 import auth.{BearerTokenAuth, Security}
 import helpers.PostrunDataCache
 import models.PremiereVersionTranslationCodec._
-import models.{FileEntry, FileEntryDAO, PremiereVersionTranslation, ProjectEntry, StorageEntry, StorageEntryHelper}
+import models._
 import play.api.Configuration
 import play.api.cache.SyncCacheApi
 import play.api.db.slick.DatabaseConfigProvider

--- a/app/models/PremiereVersionTranslationDAO.scala
+++ b/app/models/PremiereVersionTranslationDAO.scala
@@ -40,12 +40,6 @@ def findDisplayedVersionByMajor(majorVersion: Int) = db.run {
     .result
 }
 
-//  def findDisplayedVersionByMajor(majorVersion: Int) = db.run {
-//  TableQuery[PremiereVersionTranslationRow]
-//    .filter(_.displayedVersion.like(s"$majorVersion.%"))
-//    .result
-//}
-
   /**
     * Writes the given record into the table, updating an existing record if there is one or creating a new one otherwise
     * @param record PremiereVersionTranslation to write

--- a/app/models/PremiereVersionTranslationDAO.scala
+++ b/app/models/PremiereVersionTranslationDAO.scala
@@ -34,6 +34,12 @@ class PremiereVersionTranslationDAO @Inject() (dbConfigProvider:DatabaseConfigPr
     TableQuery[PremiereVersionTranslationRow].filter(_.displayedVersion===displayedVersion).result
   }
 
+  def findDisplayedVersionByMajor(majorVersion: Int) = db.run {
+  TableQuery[PremiereVersionTranslationRow]
+    .filter(_.displayedVersion.like(s"$majorVersion.%"))
+    .result
+}
+
   /**
     * Writes the given record into the table, updating an existing record if there is one or creating a new one otherwise
     * @param record PremiereVersionTranslation to write

--- a/app/models/PremiereVersionTranslationDAO.scala
+++ b/app/models/PremiereVersionTranslationDAO.scala
@@ -34,11 +34,17 @@ class PremiereVersionTranslationDAO @Inject() (dbConfigProvider:DatabaseConfigPr
     TableQuery[PremiereVersionTranslationRow].filter(_.displayedVersion===displayedVersion).result
   }
 
-  def findDisplayedVersionByMajor(majorVersion: Int) = db.run {
+def findDisplayedVersionByMajor(majorVersion: Int) = db.run {
   TableQuery[PremiereVersionTranslationRow]
-    .filter(_.displayedVersion.like(s"$majorVersion.%"))
+    .filter(row => row.displayedVersion.asColumnOf[String].like(s"$majorVersion.%"))
     .result
 }
+
+//  def findDisplayedVersionByMajor(majorVersion: Int) = db.run {
+//  TableQuery[PremiereVersionTranslationRow]
+//    .filter(_.displayedVersion.like(s"$majorVersion.%"))
+//    .result
+//}
 
   /**
     * Writes the given record into the table, updating an existing record if there is one or creating a new one otherwise

--- a/app/services/PremiereVersionConverter.scala
+++ b/app/services/PremiereVersionConverter.scala
@@ -4,7 +4,7 @@ import akka.stream.{IOResult, Materializer}
 import akka.stream.alpakka.xml.scaladsl.{XmlParsing, XmlWriting}
 import akka.stream.alpakka.xml.{Attribute, StartElement}
 import akka.stream.scaladsl.{Compression, FileIO, Keep}
-import models.{DisplayedVersion, FileEntry, FileEntryDAO, FileEntrySerializer, PremiereVersionTranslation, PremiereVersionTranslationDAO, ProjectEntry}
+import models._
 import org.apache.commons.io.FileUtils
 import org.slf4j.LoggerFactory
 import play.api.db.slick.DatabaseConfigProvider

--- a/app/services/PremiereVersionConverter.scala
+++ b/app/services/PremiereVersionConverter.scala
@@ -1,16 +1,15 @@
 package services
 
-import akka.stream.Materializer
-import akka.stream.alpakka.xml.{Attribute, StartElement}
+import akka.stream.{IOResult, Materializer}
 import akka.stream.alpakka.xml.scaladsl.{XmlParsing, XmlWriting}
+import akka.stream.alpakka.xml.{Attribute, StartElement}
 import akka.stream.scaladsl.{Compression, FileIO, Keep}
-import models.{FileEntry, FileEntryDAO, PremiereVersionTranslation, ProjectEntry, StorageEntry, StorageEntryHelper}
+import models._
 import org.apache.commons.io.FileUtils
 import org.slf4j.LoggerFactory
 import play.api.db.slick.DatabaseConfigProvider
 import postrun.{AdobeXml, RunXmlLint}
 import slick.jdbc.PostgresProfile
-import akka.stream.IOResult
 
 import java.io.File
 import java.nio.charset.StandardCharsets

--- a/app/services/PremiereVersionConverter.scala
+++ b/app/services/PremiereVersionConverter.scala
@@ -4,7 +4,7 @@ import akka.stream.{IOResult, Materializer}
 import akka.stream.alpakka.xml.scaladsl.{XmlParsing, XmlWriting}
 import akka.stream.alpakka.xml.{Attribute, StartElement}
 import akka.stream.scaladsl.{Compression, FileIO, Keep}
-import models._
+import models.{DisplayedVersion, FileEntry, FileEntryDAO, FileEntrySerializer, PremiereVersionTranslation, PremiereVersionTranslationDAO, ProjectEntry}
 import org.apache.commons.io.FileUtils
 import org.slf4j.LoggerFactory
 import play.api.db.slick.DatabaseConfigProvider

--- a/frontend/app/PremiereVersionTranslation/VersionTranslationRow.tsx
+++ b/frontend/app/PremiereVersionTranslation/VersionTranslationRow.tsx
@@ -75,7 +75,7 @@ const VersionTranslationRow: React.FC<VersionTranslationRowProps> = (props) => {
     }
   }, [name]);
 
-  const displayVersionValidator = /^\d+(\.\d+)?(\.\d+)?$/;
+  const displayVersionValidator = /^\d+\.\d+\.\d+$/;
 
   useEffect(() => {
     setDisplayedVersionValid(displayVersionValidator.test(displayedVersion));

--- a/frontend/app/PremiereVersionTranslation/VersionTranslationRow.tsx
+++ b/frontend/app/PremiereVersionTranslation/VersionTranslationRow.tsx
@@ -75,7 +75,7 @@ const VersionTranslationRow: React.FC<VersionTranslationRowProps> = (props) => {
     }
   }, [name]);
 
-  const displayVersionValidator = /^\d+\.\d+\.\d+$/;
+  const displayVersionValidator = /^\d+(\.\d+)?(\.\d+)?$/;
 
   useEffect(() => {
     setDisplayedVersionValid(displayVersionValidator.test(displayedVersion));

--- a/test/controllers/PremiereVersionConverterSpec.scala
+++ b/test/controllers/PremiereVersionConverterSpec.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import models.{DisplayedVersion, FileEntry, FileEntryDAO, PremiereVersionTranslation, PremiereVersionTranslationDAO}
+import models._
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import play.api.cache.SyncCacheApi
@@ -9,20 +9,18 @@ import play.api.db.slick.DatabaseConfigProvider
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json._
-import play.api.test.Helpers.route
-import play.api.test.{FakeHeaders, FakeRequest, WithApplication}
-import testHelpers.TestDatabase
-import utils.BuildMyApp
 import play.api.test.Helpers._
 import play.api.test._
+import testHelpers.TestDatabase
+import utils.BuildMyApp
 
-import scala.concurrent.duration._
 import java.io.File
 import java.nio.file.Path
 import java.sql.Timestamp
 import java.time.Instant
-import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
 
 class PremiereVersionConverterSpec extends Specification with Mockito with BuildMyApp {
   sequential

--- a/test/controllers/PremiereVersionConverterSpec.scala
+++ b/test/controllers/PremiereVersionConverterSpec.scala
@@ -59,7 +59,7 @@ class PremiereVersionConverterSpec extends Specification with Mockito with Build
 
       val translation = PremiereVersionTranslation(36, "Some test", DisplayedVersion(1, 2, 3))
       val mockedTranslationDAO = mock[PremiereVersionTranslationDAO]
-      mockedTranslationDAO.findDisplayedVersion(any) returns Future(Seq(translation))
+      mockedTranslationDAO.findDisplayedVersionByMajor(any) returns Future(Seq(translation))
 
       new WithApplication(buildAppWithMockedConverter(mockedConverter, mockedDAO, mockedTranslationDAO)) {
         val response = route(app, FakeRequest(
@@ -78,7 +78,7 @@ class PremiereVersionConverterSpec extends Specification with Mockito with Build
 
         status(response) mustEqual 200
 
-        there was one(mockedTranslationDAO).findDisplayedVersion(DisplayedVersion(1, 2, 3))
+        there was one(mockedTranslationDAO).findDisplayedVersionByMajor(1)
         there was one(mockedConverter).backupFile(fakeFileEntry)
         there was one(mockedConverter).checkExistingVersion(fakeFileEntry, translation)
         there was one(mockedConverter).tweakProjectVersionStreaming(mockedSourceFile, mockedBackupFile, 34, translation)
@@ -110,7 +110,7 @@ class PremiereVersionConverterSpec extends Specification with Mockito with Build
       mockedDAO.saveSimple(any) answers ((args: Array[AnyRef]) => Future(args.head.asInstanceOf[FileEntry]))
 
       val mockedTranslationDAO = mock[PremiereVersionTranslationDAO]
-      mockedTranslationDAO.findDisplayedVersion(any) returns Future(Seq())
+      mockedTranslationDAO.findDisplayedVersionByMajor(any) returns Future(Seq())
 
       new WithApplication(buildAppWithMockedConverter(mockedConverter, mockedDAO, mockedTranslationDAO)) {
         val response = route(app, FakeRequest(
@@ -128,7 +128,7 @@ class PremiereVersionConverterSpec extends Specification with Mockito with Build
 
         status(response) mustEqual 400
 
-        there was one(mockedTranslationDAO).findDisplayedVersion(DisplayedVersion(1, 2, 3))
+        there was one(mockedTranslationDAO).findDisplayedVersionByMajor(1)
         there was no(mockedConverter).backupFile(any)
         there was no(mockedConverter).checkExistingVersion(any, any)
         there was no(mockedConverter).tweakProjectVersionStreaming(any, any, any, any)
@@ -158,7 +158,7 @@ class PremiereVersionConverterSpec extends Specification with Mockito with Build
 
       val translation = PremiereVersionTranslation(36, "Some test", DisplayedVersion(1, 2, 3))
       val mockedTranslationDAO = mock[PremiereVersionTranslationDAO]
-      mockedTranslationDAO.findDisplayedVersion(any) returns Future(Seq(translation))
+      mockedTranslationDAO.findDisplayedVersionByMajor(any) returns Future(Seq(translation))
 
       new WithApplication(buildAppWithMockedConverter(mockedConverter, mockedDAO, mockedTranslationDAO)) {
         val response = route(app, FakeRequest(
@@ -176,7 +176,7 @@ class PremiereVersionConverterSpec extends Specification with Mockito with Build
 
         status(response) mustEqual 400
 
-        there was one(mockedTranslationDAO).findDisplayedVersion(DisplayedVersion(1, 2, 3))
+        there was one(mockedTranslationDAO).findDisplayedVersionByMajor(1)
         there was no(mockedConverter).backupFile(any)
         there was no(mockedConverter).checkExistingVersion(any, any)
         there was no(mockedConverter).tweakProjectVersionStreaming(any, any, any, any)
@@ -206,7 +206,7 @@ class PremiereVersionConverterSpec extends Specification with Mockito with Build
 
       val translation = PremiereVersionTranslation(36, "Some test", DisplayedVersion(1, 2, 3))
       val mockedTranslationDAO = mock[PremiereVersionTranslationDAO]
-      mockedTranslationDAO.findDisplayedVersion(any) returns Future(Seq(translation))
+      mockedTranslationDAO.findDisplayedVersionByMajor(any) returns Future(Seq(translation))
 
       new WithApplication(buildAppWithMockedConverter(mockedConverter, mockedDAO, mockedTranslationDAO)) {
         val response = route(app, FakeRequest(
@@ -223,7 +223,7 @@ class PremiereVersionConverterSpec extends Specification with Mockito with Build
 
         status(response) mustEqual 400
 
-        there was one(mockedTranslationDAO).findDisplayedVersion(DisplayedVersion(1, 2, 3))
+        there was one(mockedTranslationDAO).findDisplayedVersionByMajor(1)
         there was no(mockedConverter).backupFile(any)
         there was one(mockedConverter).checkExistingVersion(fakeFileEntry, translation)
         there was no(mockedConverter).tweakProjectVersionStreaming(any, any, any, any)
@@ -253,7 +253,7 @@ class PremiereVersionConverterSpec extends Specification with Mockito with Build
 
       val translation = PremiereVersionTranslation(36, "Some test", DisplayedVersion(1, 2, 3))
       val mockedTranslationDAO = mock[PremiereVersionTranslationDAO]
-      mockedTranslationDAO.findDisplayedVersion(any) returns Future(Seq(translation))
+      mockedTranslationDAO.findDisplayedVersionByMajor(any) returns Future(Seq(translation))
 
       new WithApplication(buildAppWithMockedConverter(mockedConverter, mockedDAO, mockedTranslationDAO)) {
         val response = route(app, FakeRequest(
@@ -271,7 +271,7 @@ class PremiereVersionConverterSpec extends Specification with Mockito with Build
 
         status(response) mustEqual 400
 
-        there was one(mockedTranslationDAO).findDisplayedVersion(DisplayedVersion(1, 2, 3))
+        there was one(mockedTranslationDAO).findDisplayedVersionByMajor(1)
         there was one(mockedConverter).backupFile(fakeFileEntry)
         there was one(mockedConverter).checkExistingVersion(fakeFileEntry, translation)
         there was no(mockedConverter).tweakProjectVersionStreaming(any, any, any, any)
@@ -300,7 +300,7 @@ class PremiereVersionConverterSpec extends Specification with Mockito with Build
 
       val translation = PremiereVersionTranslation(36, "Some test", DisplayedVersion(1, 2, 3))
       val mockedTranslationDAO = mock[PremiereVersionTranslationDAO]
-      mockedTranslationDAO.findDisplayedVersion(any) returns Future(Seq(translation))
+      mockedTranslationDAO.findDisplayedVersionByMajor(any) returns Future(Seq(translation))
 
       new WithApplication(buildAppWithMockedConverter(mockedConverter, mockedDAO, mockedTranslationDAO)) {
         val response = route(app, FakeRequest(
@@ -316,7 +316,7 @@ class PremiereVersionConverterSpec extends Specification with Mockito with Build
         (jsondata \ "status").as[String] mustEqual "error"
         status(response) mustEqual 400
 
-        there was one(mockedTranslationDAO).findDisplayedVersion(DisplayedVersion(1, 2, 3))
+        there was one(mockedTranslationDAO).findDisplayedVersionByMajor(1)
         there was one(mockedConverter).backupFile(fakeFileEntry)
         there was one(mockedConverter).checkExistingVersion(fakeFileEntry, translation)
         there was one(mockedConverter).tweakProjectVersionStreaming(mockedSourceFile, mockedBackupFile, 34, translation)


### PR DESCRIPTION
As from the release of Premiere Pro 2023, all major versions will be compatible. This PR: 
- Ignores the minor+patch part of the displayed Premiere Pro version so that projects will open as long as the major part of the version matches what is in the versions database. 
- Projects will only update if the major version has increased. 