### PR TITLE
Clarify project opening for user

### DIFF
--- a/frontend/app/PremiereVersionChange/PremiereVersionChange.tsx
+++ b/frontend/app/PremiereVersionChange/PremiereVersionChange.tsx
@@ -265,15 +265,16 @@ const PremiereVersionChange: React.FC<RouteComponentProps> = (props) => {
             </Grid>
             <Grid item>
               <Typography className={classes.centered}>
-                Ready to go! The project should open automatically in a few
-                moments. If it does not, try clicking{" "}
-                <Link
+                Ready to go! Please click{" "}
+                <Button
+                  variant="contained"
+                  color="primary"
                   onClick={() => window.open(newOpenUrl)}
                   style={{ cursor: "pointer" }}
                 >
                   here
-                </Link>{" "}
-                to open it manually
+                </Button>{" "}
+                to open project
               </Typography>
             </Grid>
           </Grid>

--- a/frontend/app/PremiereVersionChange/PremiereVersionChange.tsx
+++ b/frontend/app/PremiereVersionChange/PremiereVersionChange.tsx
@@ -198,7 +198,9 @@ const PremiereVersionChange: React.FC<RouteComponentProps> = (props) => {
         <title>Change Premiere project version</title>
       </Helmet>
       <Paper elevation={3}>
-        <Typography variant="h2">Change Premiere project's version</Typography>
+        <Typography variant="h2" style={{ textAlign: "center" }}>
+          Change Premiere project's version
+        </Typography>
         {loading || conversionInProgress ? <LinearProgress /> : undefined}
         {lastError ? (
           <Typography className={classes.centered}>
@@ -273,7 +275,10 @@ const PremiereVersionChange: React.FC<RouteComponentProps> = (props) => {
               <CheckCircle className={classes.success} />
             </Grid>
             <Grid item>
-              <Typography className={classes.centered}>
+              <Typography
+                className={classes.centered}
+                style={{ fontWeight: "bold", fontSize: "1.5em" }}
+              >
                 Ready to go! Please click{" "}
                 <Button
                   variant="contained"

--- a/frontend/app/PremiereVersionChange/PremiereVersionChange.tsx
+++ b/frontend/app/PremiereVersionChange/PremiereVersionChange.tsx
@@ -300,7 +300,7 @@ const PremiereVersionChange: React.FC<RouteComponentProps> = (props) => {
         ) : undefined}
         {newOpenUrl || lastError ? (
           <Typography className={classes.centered}>
-            You can now close this tab, or press the reload button to try again
+            You can now close this tab
           </Typography>
         ) : undefined}
       </Paper>

--- a/frontend/app/PremiereVersionChange/PremiereVersionChange.tsx
+++ b/frontend/app/PremiereVersionChange/PremiereVersionChange.tsx
@@ -43,6 +43,7 @@ const PremiereVersionChange: React.FC<RouteComponentProps> = (props) => {
 
   const [conversionInProgress, setConversionInProgress] = useState(false);
   const [newOpenUrl, setNewOpenUrl] = useState<string | undefined>(undefined);
+  const [popupBlocked, setPopupBlocked] = useState(false);
 
   const history = useHistory();
 
@@ -180,7 +181,15 @@ const PremiereVersionChange: React.FC<RouteComponentProps> = (props) => {
    * try to open the new file once we have it
    */
   useEffect(() => {
-    if (newOpenUrl && newOpenUrl != "") window.open(newOpenUrl, "_blank");
+    if (newOpenUrl && newOpenUrl !== "") {
+      const newWindow = window.open(newOpenUrl, "_blank");
+      if (!newWindow) {
+        setPopupBlocked(true);
+      } else {
+        // Successfully opened a new window, close this one.
+        window.close();
+      }
+    }
   }, [newOpenUrl]);
 
   return (
@@ -251,7 +260,7 @@ const PremiereVersionChange: React.FC<RouteComponentProps> = (props) => {
             </Grid>
           </Grid>
         ) : undefined}
-        {newOpenUrl ? (
+        {popupBlocked ? (
           <Grid container direction="column" spacing={2}>
             <Grid
               item
@@ -269,7 +278,12 @@ const PremiereVersionChange: React.FC<RouteComponentProps> = (props) => {
                 <Button
                   variant="contained"
                   color="primary"
-                  onClick={() => window.open(newOpenUrl)}
+                  onClick={() => {
+                    const newWindow = window.open(newOpenUrl);
+                    if (newWindow) {
+                      window.close();
+                    }
+                  }}
                   style={{ cursor: "pointer" }}
                 >
                   here


### PR DESCRIPTION
Chrome is preventing the automatic load of projects due to pop-up blocking.
<img width="1555" alt="Screenshot 2023-08-30 at 15 15 03" src="https://github.com/guardian/pluto-core/assets/66913730/5aff75bb-da49-43f6-9032-41acaf780780">

This change will open the project and close the window if no popup blocker is detected. If a popup blocker is detected then a message "Ready to go! Please click *here* to open project"
