### PR TITLE
Hide Bucket Options when S3 Switch Is Off

### DIFF
--- a/frontend/app/ProjectEntryList/ProjectDeleteDataComponent.tsx
+++ b/frontend/app/ProjectEntryList/ProjectDeleteDataComponent.tsx
@@ -240,30 +240,30 @@ const ProjectDeleteDataComponent: React.FC<ProjectDeleteDataComponentProps> = (
                     name="s3"
                   />
                   {s3 ? (
-                      <>
-                        <br />
-                        Buckets
-                        <br />
-                        {buckets
-                            ? buckets.map((bucket, ix) => {
-                              return (
-                                  <>
-                                    {bucket}
-                                    <Checkbox
-                                        checked={bucketBooleans[ix]}
-                                        onChange={() => {
-                                          let booleansCopy = [...bucketBooleans];
-                                          booleansCopy[ix] = !bucketBooleans[ix];
-                                          updateBucketBooleans(booleansCopy);
-                                        }}
-                                        name={bucket}
-                                    />
-                                    <br />
-                                  </>
-                              );
-                            })
-                            : null}
-                      </>
+                    <>
+                      <br />
+                      Buckets
+                      <br />
+                      {buckets
+                        ? buckets.map((bucket, ix) => {
+                            return (
+                              <>
+                                {bucket}
+                                <Checkbox
+                                  checked={bucketBooleans[ix]}
+                                  onChange={() => {
+                                    let booleansCopy = [...bucketBooleans];
+                                    booleansCopy[ix] = !bucketBooleans[ix];
+                                    updateBucketBooleans(booleansCopy);
+                                  }}
+                                  name={bucket}
+                                />
+                                <br />
+                              </>
+                            );
+                          })
+                        : null}
+                    </>
                   ) : null}
                 </Grid>
               </Grid>

--- a/frontend/app/ProjectEntryList/ProjectDeleteDataComponent.tsx
+++ b/frontend/app/ProjectEntryList/ProjectDeleteDataComponent.tsx
@@ -239,28 +239,32 @@ const ProjectDeleteDataComponent: React.FC<ProjectDeleteDataComponentProps> = (
                     onChange={() => setS3(!s3)}
                     name="s3"
                   />
-                  <br />
-                  Buckets
-                  <br />
-                  {buckets
-                    ? buckets.map((bucket, ix) => {
-                        return (
-                          <>
-                            {bucket}
-                            <Checkbox
-                              checked={bucketBooleans[ix]}
-                              onChange={() => {
-                                let booleansCopy = [...bucketBooleans];
-                                booleansCopy[ix] = !bucketBooleans[ix];
-                                updateBucketBooleans(booleansCopy);
-                              }}
-                              name={bucket}
-                            />
-                            <br />
-                          </>
-                        );
-                      })
-                    : null}
+                  {s3 ? (
+                      <>
+                        <br />
+                        Buckets
+                        <br />
+                        {buckets
+                            ? buckets.map((bucket, ix) => {
+                              return (
+                                  <>
+                                    {bucket}
+                                    <Checkbox
+                                        checked={bucketBooleans[ix]}
+                                        onChange={() => {
+                                          let booleansCopy = [...bucketBooleans];
+                                          booleansCopy[ix] = !bucketBooleans[ix];
+                                          updateBucketBooleans(booleansCopy);
+                                        }}
+                                        name={bucket}
+                                    />
+                                    <br />
+                                  </>
+                              );
+                            })
+                            : null}
+                      </>
+                  ) : null}
                 </Grid>
               </Grid>
               <div>


### PR DESCRIPTION
## What does this change?

Hides the bucket options when the S3 switch is off.

## Images

Off.

![image](https://github.com/guardian/pluto-core/assets/10620802/e3f2a0a5-1afe-4580-8c32-70a23e004fef)

On.

![image](https://github.com/guardian/pluto-core/assets/10620802/303aba35-9ba9-4ae0-9008-41015d0743a1)

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2.