### PR TITLE
Do not allow users to change filename unless admin

### DIFF
--- a/frontend/app/multistep/ProjectCreateMultistepNew.tsx
+++ b/frontend/app/multistep/ProjectCreateMultistepNew.tsx
@@ -145,9 +145,7 @@ const ProjectCreateMultistepNew: React.FC<RouteComponentProps> = (props) => {
   useEffect(() => {
     console.log("User context changed, new value: ", context);
     if (projectName == "") {
-      setProjectName(
-        context?.userName ? `${context.userName}'s project` : "My project"
-      );
+      setProjectName("Type a good descriptive project name here");
     }
   }, [context]);
 

--- a/frontend/app/multistep/ProjectCreateMultistepNew.tsx
+++ b/frontend/app/multistep/ProjectCreateMultistepNew.tsx
@@ -144,9 +144,6 @@ const ProjectCreateMultistepNew: React.FC<RouteComponentProps> = (props) => {
 
   useEffect(() => {
     console.log("User context changed, new value: ", context);
-    if (projectName == "") {
-      setProjectName("Type a good descriptive project name here");
-    }
   }, [context]);
 
   /**

--- a/frontend/app/multistep/projectcreate_new/NameComponent.tsx
+++ b/frontend/app/multistep/projectcreate_new/NameComponent.tsx
@@ -136,6 +136,7 @@ const NameComponent: React.FC<NameComponentProps> = (props) => {
                 onChange={(event) =>
                   props.projectNameDidChange(event.target.value)
                 }
+                placeholder="Type a good descriptive project name here"
                 value={props.projectName}
               />
             </td>

--- a/frontend/app/multistep/projectcreate_new/NameComponent.tsx
+++ b/frontend/app/multistep/projectcreate_new/NameComponent.tsx
@@ -16,6 +16,8 @@ import {
 import StorageSelector from "../../Selectors/StorageSelector";
 import { getProjectsDefaultStorageId } from "./ProjectStorageService";
 import { useGuardianStyles } from "~/misc/utils";
+import { isLoggedIn } from "~/utils/api";
+import ObituarySelector from "../../common/ObituarySelector";
 
 interface NameComponentProps {
   projectName: string;
@@ -33,6 +35,7 @@ const NameComponent: React.FC<NameComponentProps> = (props) => {
   const classes = useGuardianStyles();
 
   const userContext = useContext(UserContext);
+  const [isAdmin, setIsAdmin] = useState<boolean>(false);
 
   const loadStorages = async () => {
     setLoading(true);
@@ -103,6 +106,17 @@ const NameComponent: React.FC<NameComponentProps> = (props) => {
     }
   }, [knownStorages]);
 
+  const fetchWhoIsLoggedIn = async () => {
+    try {
+      const loggedIn = await isLoggedIn();
+      setIsAdmin(loggedIn.isAdmin);
+    } catch {
+      setIsAdmin(false);
+    }
+  };
+
+  fetchWhoIsLoggedIn();
+
   return (
     <div className={classes.common_box_size}>
       <Typography variant="h3">Name your project</Typography>
@@ -126,64 +140,69 @@ const NameComponent: React.FC<NameComponentProps> = (props) => {
               />
             </td>
           </tr>
-          <tr>
-            <td>
-              <Typography>File name</Typography>
-            </td>
-            <td>
-              <Input
-                className={classes.inputBox}
-                id="fileNameInput"
-                onChange={(event) =>
-                  props.fileNameDidChange(event.target.value)
-                }
-                value={props.fileName}
-                disabled={autoName}
-              />
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <Typography>Automatically name file (recommended)</Typography>
-            </td>
-            <td>
-              <Switch
-                id="autoNameCheck"
-                checked={autoName}
-                onChange={(event) => setAutoName(event.target.checked)}
-              />
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <Typography>Project storage</Typography>
-            </td>
-            <td>
-              <Grid direction="row" container>
-                <Grid item>
-                  <StorageSelector
-                    storageList={knownStorages}
-                    enabled={userContext?.isAdmin}
-                    selectionUpdated={(newValue: number) =>
-                      props.storageIdDidChange(newValue)
+          {console.log("IsAdmin: ", isAdmin)}
+          {!isAdmin && (
+            <>
+              <tr>
+                <td>
+                  <Typography>File name</Typography>
+                </td>
+                <td>
+                  <Input
+                    className={classes.inputBox}
+                    id="fileNameInput"
+                    onChange={(event) =>
+                      props.fileNameDidChange(event.target.value)
                     }
-                    selectedStorage={props.selectedStorageId}
+                    value={props.fileName}
+                    disabled={autoName}
                   />
-                  {userContext?.isAdmin ? undefined : (
-                    <Typography className={classes.secondary}>
-                      Only administrators can change the project storage
-                      location
-                    </Typography>
-                  )}
-                </Grid>
-                <Grid item>
-                  {loading ? (
-                    <CircularProgress style={{ height: "0.8em" }} />
-                  ) : undefined}
-                </Grid>
-              </Grid>
-            </td>
-          </tr>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <Typography>Automatically name file (recommended)</Typography>
+                </td>
+                <td>
+                  <Switch
+                    id="autoNameCheck"
+                    checked={autoName}
+                    onChange={(event) => setAutoName(event.target.checked)}
+                  />
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <Typography>Project storage</Typography>
+                </td>
+                <td>
+                  <Grid container direction="row">
+                    <Grid item>
+                      <StorageSelector
+                        storageList={knownStorages}
+                        enabled={userContext?.isAdmin}
+                        selectionUpdated={(newValue: number) =>
+                          props.storageIdDidChange(newValue)
+                        }
+                        selectedStorage={props.selectedStorageId}
+                      />
+                      {!userContext?.isAdmin && (
+                        <Typography className={classes.secondary}>
+                          Only administrators can change the project storage
+                          location
+                        </Typography>
+                      )}
+                    </Grid>
+                    <Grid item>
+                      {loading && (
+                        <CircularProgress style={{ height: "0.8em" }} />
+                      )}
+                    </Grid>
+                  </Grid>
+                </td>
+              </tr>
+            </>
+          )}
         </tbody>
       </table>
     </div>

--- a/frontend/app/multistep/projectcreate_new/NameComponent.tsx
+++ b/frontend/app/multistep/projectcreate_new/NameComponent.tsx
@@ -141,7 +141,7 @@ const NameComponent: React.FC<NameComponentProps> = (props) => {
             </td>
           </tr>
           {console.log("IsAdmin: ", isAdmin)}
-          {!isAdmin && (
+          {isAdmin && (
             <>
               <tr>
                 <td>

--- a/frontend/app/styles/app.css
+++ b/frontend/app/styles/app.css
@@ -559,3 +559,8 @@ table tbody th {
   margin-right: 0.5em;
   margin-top: 0.57em;
 }
+
+#projectNameInput::placeholder {
+  color: grey;
+  font-style: italic;
+}


### PR DESCRIPTION
This change removes unnecessary content for non-admin users when creating a new project.
The project name placeholder has also been changed to encourage users to use a descriptive project name.

Non-admin users will now see this at step 2 of creating a project:
![Screenshot 2023-09-27 at 11 21 30](https://github.com/guardian/pluto-core/assets/66913730/dbb7ec7a-236f-4807-b281-b88193ca9312)
