### PR TITLE
Edit project on row click

### DIFF
--- a/frontend/app/ObituariesList/ObituariesList.tsx
+++ b/frontend/app/ObituariesList/ObituariesList.tsx
@@ -280,7 +280,12 @@ const ObituariesList = () => {
                     >
                       Open project
                     </Button>
-                    <AssetFolderLink projectId={project.id} />
+                    <AssetFolderLink
+                      projectId={project.id}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                      }}
+                    />
                   </TableCell>
                 </TableRow>
               ))}

--- a/frontend/app/ProjectEntryList/AssetFolderLink.tsx
+++ b/frontend/app/ProjectEntryList/AssetFolderLink.tsx
@@ -6,6 +6,7 @@ import FolderIcon from "@material-ui/icons/Folder";
 
 interface AssetFolderLinkProps {
   projectId: number;
+  onClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 }
 
 const AssetFolderLink: React.FC<AssetFolderLinkProps> = (props) => {
@@ -45,7 +46,10 @@ const AssetFolderLink: React.FC<AssetFolderLinkProps> = (props) => {
     loadData();
   }, [props.projectId]);
 
-  const requestNewAssetFolder = async () => {
+  const requestNewAssetFolder = async (event: {
+    stopPropagation: () => void;
+  }) => {
+    event.stopPropagation();
     loadData();
   };
 
@@ -59,7 +63,7 @@ const AssetFolderLink: React.FC<AssetFolderLinkProps> = (props) => {
             No asset folder found
             <Tooltip title="Check again">
               <IconButton
-                onClick={requestNewAssetFolder}
+                onClick={(event) => requestNewAssetFolder(event)}
                 style={{ marginLeft: "1em" }}
               >
                 <ReplayIcon />
@@ -73,6 +77,7 @@ const AssetFolderLink: React.FC<AssetFolderLinkProps> = (props) => {
           style={{ minWidth: "160px", minHeight: "35px" }}
           href={`pluto:openfolder:${assetFolderPath}`}
           variant="contained"
+          onClick={props.onClick}
         >
           Asset&nbsp;folder
         </Button>

--- a/frontend/app/ProjectEntryList/AssetFolderLink.tsx
+++ b/frontend/app/ProjectEntryList/AssetFolderLink.tsx
@@ -1,6 +1,12 @@
 import React, { useEffect, useState } from "react";
 import axios from "axios";
-import { Button, Typography, IconButton, Tooltip } from "@material-ui/core";
+import {
+  Button,
+  Typography,
+  IconButton,
+  Tooltip,
+  makeStyles,
+} from "@material-ui/core";
 import ReplayIcon from "@material-ui/icons/Replay";
 import FolderIcon from "@material-ui/icons/Folder";
 
@@ -14,7 +20,16 @@ const AssetFolderLink: React.FC<AssetFolderLinkProps> = (props) => {
   const [loading, setLoading] = useState<boolean>(false);
   const [assetFolderPath, setAssetFolderPath] = useState<string>("");
   const [showCreate, setShowCreate] = useState<boolean>(false);
-
+  const useStyles = makeStyles((theme) => ({
+    button: {
+      minWidth: "160px",
+      minHeight: "35px",
+      "&:hover": {
+        backgroundColor: "#A9A9A9",
+      },
+    },
+  }));
+  const classes = useStyles();
   const loadData = async () => {
     setLoading(true);
 
@@ -74,7 +89,7 @@ const AssetFolderLink: React.FC<AssetFolderLinkProps> = (props) => {
       ) : (
         <Button
           startIcon={<FolderIcon />}
-          style={{ minWidth: "160px", minHeight: "35px" }}
+          className={classes.button}
           href={`pluto:openfolder:${assetFolderPath}`}
           variant="contained"
           onClick={props.onClick}

--- a/frontend/app/ProjectEntryList/ProjectEntryEditComponent.tsx
+++ b/frontend/app/ProjectEntryList/ProjectEntryEditComponent.tsx
@@ -296,7 +296,12 @@ const ProjectEntryEditComponent: React.FC<ProjectEntryEditComponentProps> = (
               Open project
             </Button>
             <div style={{ marginRight: "-6px", minWidth: "129px" }}>
-              <AssetFolderLink projectId={project.id} />
+              <AssetFolderLink
+                projectId={project.id}
+                onClick={(event) => {
+                  event.stopPropagation();
+                }}
+              />
             </div>
             <Tooltip title="Press this button to fix any permissions issues in this projects' asset folder.">
               <Button

--- a/frontend/app/ProjectEntryList/ProjectsTable.tsx
+++ b/frontend/app/ProjectEntryList/ProjectsTable.tsx
@@ -236,6 +236,7 @@ const ProjectsTable: React.FC<ProjectsTableProps> = (props) => {
               } = project;
               return (
                 <TableRow
+                  className={classes.hoverRow}
                   key={id}
                   hover
                   style={{

--- a/frontend/app/ProjectEntryList/ProjectsTable.tsx
+++ b/frontend/app/ProjectEntryList/ProjectsTable.tsx
@@ -57,9 +57,10 @@ const ActionIcons: React.FC<{ id: number; isAdmin?: boolean }> = ({
   isAdmin = false,
 }) => (
   <IconButton
-    onClick={(event) =>
-      window.open(`${deploymentRootPath}project/${id}`, "_blank")
-    }
+    onClick={(event) => {
+      event.stopPropagation();
+      window.open(`${deploymentRootPath}project/${id}`, "_blank");
+    }}
   >
     <EditIcon />
   </IconButton>
@@ -242,6 +243,9 @@ const ProjectsTable: React.FC<ProjectsTableProps> = (props) => {
                       projectTypeData[projectTypeId]
                     ),
                   }}
+                  onClick={() =>
+                    window.open(`${deploymentRootPath}project/${id}`, "_blank")
+                  }
                 >
                   <TableCell>{title}</TableCell>
                   <TableCell>
@@ -261,19 +265,19 @@ const ProjectsTable: React.FC<ProjectsTableProps> = (props) => {
                     <img src={imagePath(projectTypeData[projectTypeId])} />
                   </TableCell>
                   <TableCell>
-                    <Box width="100px">
-                      <span className="icons">
-                        <ActionIcons id={id} isAdmin={props.isAdmin ?? false} />
-                        <IconButton
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            setUpdatingProject(id);
-                            setOpenDialog(true);
-                          }}
-                        >
-                          <DeleteIcon />
-                        </IconButton>
-                      </span>
+                    <Box width="50px">
+                      {/* <span className="icons"> */}
+                      {/* <ActionIcons id={id} isAdmin={props.isAdmin ?? false} /> */}
+                      <IconButton
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          setUpdatingProject(id);
+                          setOpenDialog(true);
+                        }}
+                      >
+                        <DeleteIcon />
+                      </IconButton>
+                      {/* </span> */}
                     </Box>
                   </TableCell>
                   <TableCell>
@@ -281,7 +285,8 @@ const ProjectsTable: React.FC<ProjectsTableProps> = (props) => {
                       className={classes.openProjectButton}
                       variant="contained"
                       color="primary"
-                      onClick={async () => {
+                      onClick={async (event) => {
+                        event.stopPropagation();
                         try {
                           await openProject(id);
                         } catch (error) {

--- a/frontend/app/ProjectEntryList/ProjectsTable.tsx
+++ b/frontend/app/ProjectEntryList/ProjectsTable.tsx
@@ -325,7 +325,12 @@ const ProjectsTable: React.FC<ProjectsTableProps> = (props) => {
                     </Button>
                   </TableCell>
                   <TableCell>
-                    <AssetFolderLink projectId={id} />
+                    <AssetFolderLink
+                      projectId={id}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                      }}
+                    />
                   </TableCell>
                 </TableRow>
               );

--- a/frontend/app/ProjectEntryList/ProjectsTable.tsx
+++ b/frontend/app/ProjectEntryList/ProjectsTable.tsx
@@ -281,8 +281,6 @@ const ProjectsTable: React.FC<ProjectsTableProps> = (props) => {
                   </TableCell>
                   <TableCell>
                     <Box width="50px">
-                      {/* <span className="icons"> */}
-                      {/* <ActionIcons id={id} isAdmin={props.isAdmin ?? false} /> */}
                       <IconButton
                         onClick={(event) => {
                           event.stopPropagation();
@@ -292,7 +290,6 @@ const ProjectsTable: React.FC<ProjectsTableProps> = (props) => {
                       >
                         <DeleteIcon />
                       </IconButton>
-                      {/* </span> */}
                     </Box>
                   </TableCell>
                   <TableCell>

--- a/frontend/app/ProjectEntryList/ProjectsTable.tsx
+++ b/frontend/app/ProjectEntryList/ProjectsTable.tsx
@@ -17,6 +17,7 @@ import {
   TableSortLabel,
   Box,
   useTheme,
+  makeStyles,
 } from "@material-ui/core";
 import { SortDirection, sortListByOrder } from "../utils/lists";
 import CommissionEntryView from "../EntryViews/CommissionEntryView";
@@ -29,6 +30,7 @@ import {
   getSimpleProjectTypeData,
 } from "./helpers";
 import AssetFolderLink from "./AssetFolderLink";
+import Color from "color";
 import EditIcon from "@material-ui/icons/Edit";
 import DeleteIcon from "@material-ui/icons/Delete";
 import {
@@ -180,6 +182,7 @@ const ProjectsTable: React.FC<ProjectsTableProps> = (props) => {
       Prelude: "#5e382c",
       Audition: "#2d533d",
       Migrated: "#414141",
+      defaultType: "#A9A9A9",
     };
     const lightColours: any = {
       Cubase: "#ffd8e3",
@@ -188,6 +191,7 @@ const ProjectsTable: React.FC<ProjectsTableProps> = (props) => {
       Prelude: "#ffdccf",
       Audition: "#d1ffe5",
       Migrated: "#ffffff",
+      defaultType: "#A9A9A9",
     };
     if (detectDarkTheme()) {
       return darkColours[typeName];
@@ -234,15 +238,25 @@ const ProjectsTable: React.FC<ProjectsTableProps> = (props) => {
                 user: projectUser,
                 projectTypeId,
               } = project;
+
+              const backgroundColour = backgroundColourForType(
+                projectTypeData[projectTypeId] || "defaultType"
+              );
+
               return (
                 <TableRow
-                  className={classes.hoverRow}
-                  key={id}
-                  hover
                   style={{
-                    backgroundColor: backgroundColourForType(
-                      projectTypeData[projectTypeId]
-                    ),
+                    backgroundColor: backgroundColour,
+                  }}
+                  onMouseOver={(e) => {
+                    e.currentTarget.style.backgroundColor = Color(
+                      backgroundColour
+                    )
+                      .darken(0.1)
+                      .string();
+                  }}
+                  onMouseOut={(e) => {
+                    e.currentTarget.style.backgroundColor = backgroundColour;
                   }}
                   onClick={() =>
                     window.open(`${deploymentRootPath}project/${id}`, "_blank")

--- a/frontend/app/misc/utils.ts
+++ b/frontend/app/misc/utils.ts
@@ -432,9 +432,4 @@ export const useGuardianStyles = makeStyles((theme) => ({
       backgroundColor: "transparent",
     },
   },
-  hoverRow: {
-    "&:hover": {
-      backgroundColor: theme.palette.action.hover, // You can replace this with any color you prefer
-    },
-  },
 }));

--- a/frontend/app/misc/utils.ts
+++ b/frontend/app/misc/utils.ts
@@ -432,4 +432,9 @@ export const useGuardianStyles = makeStyles((theme) => ({
       backgroundColor: "transparent",
     },
   },
+  hoverRow: {
+    "&:hover": {
+      backgroundColor: theme.palette.action.hover, // You can replace this with any color you prefer
+    },
+  },
 }));

--- a/frontend/app/multistep/projectcreate_new/ProjectCreatedComponent.tsx
+++ b/frontend/app/multistep/projectcreate_new/ProjectCreatedComponent.tsx
@@ -76,7 +76,12 @@ const ProjectCreatedComponent: React.FC<ProjectCreatedComponentProps> = (
           </Typography>
         </Grid>
         <Grid item xs={4}>
-          <AssetFolderLink projectId={props.projectId} />
+          <AssetFolderLink
+            projectId={props.projectId}
+            onClick={(event) => {
+              event.stopPropagation();
+            }}
+          />
         </Grid>
         <Grid item xs={8}>
           <Typography>Start work on the project</Typography>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -92,6 +92,7 @@
     "@types/jsonwebtoken": "^8.5.0",
     "@types/react-helmet": "^6.1.0",
     "axios": "^0.21.3",
+    "color": "^4.2.3",
     "crypto-browserify": "^3.12.0",
     "css-loader": "^5.2.4",
     "date-fns": "^2.22.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,7 @@
   "author": "Andy Gallagher <andy.gallagher@theguardian.com>",
   "license": "ISC",
   "devDependencies": {
+    "@types/color": "^3.0.5",
     "@types/enzyme": "^3.10.8",
     "@types/jest": "^26.0.22",
     "@types/js-cookie": "^2.2.6",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -868,10 +868,29 @@
   dependencies:
     "@types/node" "*"
 
+"@types/color-convert@*":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@types/color-convert/-/color-convert-2.0.2.tgz#a5fa5da9b866732f8bf86b01964869011e2a2356"
+  integrity sha512-KGRIgCxwcgazts4MXRCikPbIMzBpjfdgEZSy8TRHU/gtg+f9sOfHdtK8unPfxIoBtyd2aTTwINVLSNENlC8U8A==
+  dependencies:
+    "@types/color-name" "*"
+
+"@types/color-name@*":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.2.tgz#bdeeb6fdcb78969033767951ab0cb26c7514a658"
+  integrity sha512-JWO/ZyxTKk0bLuOhAavGjnwLR73rUE7qzACnU7gMeyA/gdrSHm2xJwqNPipw2MtaZUaqQ2UG/q7pP6AQiZ8mqw==
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
+"@types/color@^3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@types/color/-/color-3.0.5.tgz#658fd9286a44c21dabaa56c2e2f63da3ac15f063"
+  integrity sha512-T9yHCNtd8ap9L/r8KEESu5RDMLkoWXHo7dTureNoI1dbp25NsCN054vOu09iniIjR21MXUL+LU9bkIWrbyg8gg==
+  dependencies:
+    "@types/color-convert" "*"
 
 "@types/enzyme@^3.10.8":
   version "3.10.8"
@@ -2112,10 +2131,26 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@~1.1.4:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.9.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
+  integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
+color@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/color/-/color-4.2.3.tgz#d781ecb5e57224ee43ea9627560107c0e0c6463a"
+  integrity sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==
+  dependencies:
+    color-convert "^2.0.1"
+    color-string "^1.9.0"
 
 colorette@^1.2.1, colorette@^1.2.2:
   version "1.2.2"
@@ -3604,6 +3639,11 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
+
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
 is-bigint@^1.0.1:
   version "1.0.1"
@@ -6834,6 +6874,13 @@ signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
+
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==
+  dependencies:
+    is-arrayish "^0.3.1"
 
 sinon@^8.0.4:
   version "8.1.1"


### PR DESCRIPTION
This change allows users to navigate to the Edit Project page on a row click. Previously this was done by clicking a pencil icon.  Rows and the Asset Folder button now lighten on the row for clarity.

<img width="1754" alt="Screenshot 2023-11-02 at 10 48 04" src="https://github.com/guardian/pluto-core/assets/66913730/82e5e09b-fc87-417c-ad74-117e447647cd">
