### PR TITLE
Use radio buttons for media management options

### DIFF
--- a/frontend/app/ProjectEntryList/ApplicableRulesSelector.tsx
+++ b/frontend/app/ProjectEntryList/ApplicableRulesSelector.tsx
@@ -18,7 +18,7 @@ interface ApplicableRulesSelectorProps {
   deletable: boolean;
   deep_archive: boolean;
   sensitive: boolean;
-  onChange: (field: keyof Project, prevValue: boolean) => void;
+  onChange: (newDeletable: boolean, newDeepArchive: boolean) => void;
   disabled: boolean;
 }
 
@@ -53,14 +53,13 @@ const ApplicableRulesSelector: React.FC<ApplicableRulesSelectorProps> = (
     if (value in props) {
       const key = value as keyof ApplicableRulesSelectorProps;
       console.log("Key: ", key);
-      if (key === "deletable" && props.deep_archive) {
+      if (key === "deletable") {
         setPendingChange({ field: key, prevValue: props[key] });
         setOpenDialog(true);
-      } else if (key === "deep_archive" && props.deletable) {
+      } else if (key === "deep_archive") {
         setPendingChange({ field: key, prevValue: props[key] });
         setSelectedOption(value);
-        const projectKey = key as keyof Project;
-        props.onChange(projectKey, props[key] as boolean);
+        props.onChange(false, true);
       }
     }
   };
@@ -68,14 +67,7 @@ const ApplicableRulesSelector: React.FC<ApplicableRulesSelectorProps> = (
   const handleDialogClose = (confirm: boolean) => {
     setOpenDialog(false);
     if (confirm && pendingChange) {
-      setSelectedOption("deletable");
-      props.onChange("deletable", false);
-      props.onChange("deep_archive", true);
-    } else if (pendingChange) {
-      console.log("Else: (pendingChange)", pendingChange);
-      setSelectedOption("deep_archive");
-      props.onChange("deletable", true);
-      props.onChange("deep_archive", false);
+      props.onChange(true, false);
     }
     setPendingChange(null);
   };

--- a/frontend/app/ProjectEntryList/ProjectEntryEditComponent.tsx
+++ b/frontend/app/ProjectEntryList/ProjectEntryEditComponent.tsx
@@ -183,6 +183,17 @@ const ProjectEntryEditComponent: React.FC<ProjectEntryEditComponentProps> = (
     setProject({ ...project, [field]: !checked });
   };
 
+  const updateDeletableAndDeepArchive = (
+    newDeletable: boolean,
+    newDeepArchive: boolean
+  ) => {
+    setProject((prevProject) => ({
+      ...prevProject,
+      deletable: newDeletable,
+      deep_archive: newDeepArchive,
+    }));
+  };
+
   const subComponentErrored = (errorDesc: string) => {
     SystemNotification.open(SystemNotifcationKind.Error, errorDesc);
   };
@@ -439,7 +450,7 @@ const ProjectEntryEditComponent: React.FC<ProjectEntryEditComponentProps> = (
                 deletable={project.deletable}
                 deep_archive={project.deep_archive}
                 sensitive={project.sensitive}
-                onChange={checkboxChanged}
+                onChange={updateDeletableAndDeepArchive}
                 disabled={!isAdmin}
               />
 


### PR DESCRIPTION
## What does this change?

This change prevents users from setting both Deep Archive and Deletable as they are mutually exclusive. An "Are you sure?" dialogue box appears when changing the setting from Deep Archive to Deletable. 

## How to test

Tested on local minikube and the dev system

## Images
<img width="882" alt="Screenshot 2024-01-11 at 16 29 30" src="https://github.com/guardian/pluto-core/assets/66913730/cef844e8-8ee4-410a-bcd7-873614eeda59">


<img width="1263" alt="Screenshot 2024-01-11 at 16 29 45" src="https://github.com/guardian/pluto-core/assets/66913730/fde90d14-c7de-4d6c-bdb6-da8b89c7f53e">
