### PR TITLE
Deletion of Pointless Audio Backups

### DIFF
--- a/app/services/BackupLauncher.scala
+++ b/app/services/BackupLauncher.scala
@@ -12,12 +12,13 @@ import scala.concurrent.ExecutionContext.Implicits.global
 object BackupLauncher {
   private val logger = LoggerFactory.getLogger(getClass)
 
-  case class Options(nukeInvalidBackups:Boolean, backupAll:Boolean)
+  case class Options(nukeInvalidBackups:Boolean, backupAll:Boolean, deleteAudioBackups:Boolean)
   val parser = new OptionParser[Options]("backup-launcher") {
     head("backup-launcher", "1")
 
     opt[Boolean]("nuke-invalid") action { (x,c)=>c.copy(nukeInvalidBackups = x)} text("instead of launching a backup, remove zero-length backup files")
     opt[Boolean]("all") action { (x,c)=>c.copy(backupAll = x)} text "try to back up every project instead of just 'in production'"
+    opt[Boolean]("delete-audio") action { (x,c)=>c.copy(deleteAudioBackups = x)} text("Instead of launching a backup, remove audio backup files")
   }
 
   def main(args:Array[String]):Unit = {
@@ -28,13 +29,23 @@ object BackupLauncher {
     implicit val injector = app.injector
     val projectBackup = injector.instanceOf(classOf[NewProjectBackup])
 
-    parser.parse(args, Options(false, false)) match {
+    parser.parse(args, Options(false, false, false)) match {
       case Some(opts) =>
 
         if (opts.nukeInvalidBackups) {
           projectBackup.nukeInvalidBackups.onComplete({
             case Success(r) =>
               println(s"Nuked ${r.successCount} dodgy backups")
+              System.exit(0)
+            case Failure(exception) =>
+              println(s"ERROR - Could not complete scan: ${exception.getMessage}")
+              exception.printStackTrace()
+              System.exit(1)
+          })
+        } else if (opts.deleteAudioBackups) {
+          projectBackup.deleteAudioBackups.onComplete({
+            case Success(r) =>
+              println(s"Attempted to delete ${r.successCount} backups")
               System.exit(0)
             case Failure(exception) =>
               println(s"ERROR - Could not complete scan: ${exception.getMessage}")

--- a/app/services/NewProjectBackup.scala
+++ b/app/services/NewProjectBackup.scala
@@ -542,13 +542,14 @@ class NewProjectBackup @Inject() (config:Configuration, dbConfigProvider: Databa
           case Some(driver)=>
             if(fileEntry.storageId!=2) {
               logger.info(s"Deleting backup ${fileEntry.filepath} on storage id ${fileEntry.storageId}")
-              if (driver.deleteFileAtPath(fileEntry.filepath, fileEntry.version)) {
+              /*if (driver.deleteFileAtPath(fileEntry.filepath, fileEntry.version)) {
                 logger.info(s"Deleting backup entry ${fileEntry.id}")
                 fileEntry.deleteSelf
               } else {
                 logger.error(s"Could not delete file ${fileEntry.filepath} on storage id ${fileEntry.storageId}")
                 Future( () )
-              }
+              }*/
+              Future( () )
             } else {
               Future( () )
             }

--- a/app/services/NewProjectBackup.scala
+++ b/app/services/NewProjectBackup.scala
@@ -542,14 +542,13 @@ class NewProjectBackup @Inject() (config:Configuration, dbConfigProvider: Databa
           case Some(driver)=>
             if(fileEntry.storageId!=2) {
               logger.info(s"Deleting backup ${fileEntry.filepath} on storage id ${fileEntry.storageId}")
-              /*if (driver.deleteFileAtPath(fileEntry.filepath, fileEntry.version)) {
+              if (driver.deleteFileAtPath(fileEntry.filepath, fileEntry.version)) {
                 logger.info(s"Deleting backup entry ${fileEntry.id}")
                 fileEntry.deleteSelf
               } else {
                 logger.error(s"Could not delete file ${fileEntry.filepath} on storage id ${fileEntry.storageId}")
                 Future( () )
-              }*/
-              Future( () )
+              }
             } else {
               Future( () )
             }


### PR DESCRIPTION
## What does this change?

Adds a new job that deletes audio backup files and their database entries. 

## How can we measure success?

The correct data is deleted.

## Have we considered potential risks?

This only works on the FileEntry table so the new audio backups that are referenced in the AssetFolderFileEntry table will be safe.

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.