### PR TITLE
Stop Use of Underscores in Commission and Project Titles

### DIFF
--- a/frontend/app/multistep/commissioncreate_new/CommissionTitleComponent.tsx
+++ b/frontend/app/multistep/commissioncreate_new/CommissionTitleComponent.tsx
@@ -11,6 +11,10 @@ import ProductionOfficeComponent from "../projectcreate_new/ProductionOfficeComp
 import WorkingGroupSelector from "../common/WorkingGroupSelector";
 import { loadWorkingGroups } from "../common/WorkingGroupService";
 import { Autocomplete } from "@material-ui/lab";
+import {
+  SystemNotifcationKind,
+  SystemNotification,
+} from "@guardian/pluto-headers";
 
 interface CommissionTitleComponentProps {
   title: string;
@@ -50,7 +54,15 @@ const CommissionTitleComponent: React.FC<CommissionTitleComponentProps> = (
                 helperText="Enter a good descriptive Commission title"
                 margin="normal"
                 id="commissionNameInput"
-                onChange={(event) => props.onTitleChanged(event.target.value)}
+                onChange={(event) => {
+                  props.onTitleChanged(event.target.value.replace(/[_]/g, ""));
+                  if (event.target.value.includes("_")) {
+                    SystemNotification.open(
+                      SystemNotifcationKind.Warning,
+                      "Underscores should not be used in commission titles."
+                    );
+                  }
+                }}
                 value={props.title}
               />
             </Grid>

--- a/frontend/app/multistep/projectcreate_new/ConfigurationComponent.tsx
+++ b/frontend/app/multistep/projectcreate_new/ConfigurationComponent.tsx
@@ -143,9 +143,17 @@ const ConfigurationComponent: React.FC<ConfigurationComponentProps> = (
                 helperText="Enter a good descriptive project name"
                 margin="normal"
                 id="projectNameInput"
-                onChange={(event) =>
-                  props.projectNameDidChange(event.target.value)
-                }
+                onChange={(event) => {
+                  props.projectNameDidChange(
+                    event.target.value.replace(/[_]/g, "")
+                  );
+                  if (event.target.value.includes("_")) {
+                    SystemNotification.open(
+                      SystemNotifcationKind.Warning,
+                      "Underscores should not be used in project titles."
+                    );
+                  }
+                }}
                 value={props.projectName}
               />
             </Grid>


### PR DESCRIPTION
## What does this change?

Stops the use of underscores in commission and project titles. If the user enters an underscore a warning will be displayed.

## How can we measure success?

Underscores can now not be used in commission and project titles.

## Images

![PC108](https://github.com/guardian/pluto-core/assets/10620802/2c478e59-d530-4e34-8226-94f4390d2b05)

![PC107](https://github.com/guardian/pluto-core/assets/10620802/d407b612-39fb-433e-be96-181f0ef4fe82)

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.