### PR TITLE
Persistent Deletion Records

### DIFF
--- a/app/controllers/DeleteJobController.scala
+++ b/app/controllers/DeleteJobController.scala
@@ -1,0 +1,33 @@
+package controllers
+
+import javax.inject._
+import auth.{BearerTokenAuth, Security}
+import models.{DeleteJobDAO, DeleteJobSerializer}
+import play.api.{Configuration, Logger}
+import play.api.cache.SyncCacheApi
+import play.api.db.slick.DatabaseConfigProvider
+import play.api.libs.json._
+import play.api.mvc.{AbstractController, ControllerComponents}
+import slick.jdbc.PostgresProfile
+import scala.util.{Failure, Success}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+@Singleton
+class DeleteJobController @Inject() (cc:ControllerComponents, override val bearerTokenAuth:BearerTokenAuth,
+                                          override implicit val config: Configuration,
+                                          dbConfigProvider: DatabaseConfigProvider, cacheImpl:SyncCacheApi)
+  extends AbstractController(cc) with Security with DeleteJobSerializer {
+  override val logger = Logger(getClass)
+
+  implicit val cache = cacheImpl
+  implicit val db = dbConfigProvider.get[PostgresProfile].db
+
+  def deleted(startAt:Int, limit: Int) = IsAdminAsync {uid=>{request=>
+    DeleteJobDAO.getJobs(startAt, limit).map({
+      case Success(results)=>Ok(Json.obj("status"->"ok","result"->results))
+      case Failure(error)=>
+        logger.error("Could not list deleted projects: ", error)
+        InternalServerError(Json.obj("status"->"error","detail"->error.toString))
+    })
+  }}
+}

--- a/conf/routes
+++ b/conf/routes
@@ -49,6 +49,7 @@ GET     /api/project/obits                  @controllers.ProjectEntryController.
 
 PUT     /api/project                        @controllers.ProjectEntryController.create
 GET     /api/project/forFilename            @controllers.Files.projectFromFile(filename: String,startAt:Int ?= 0,limit:Int ?=50, includeBackups:Boolean ?=false)
+GET     /api/project/deleted                @controllers.DeleteJobController.deleted(startAt:Int ?=0,length:Int ?=100)
 GET     /api/project/:id/files              @controllers.ProjectEntryController.filesList(id:Int, allVersions:Boolean ?=false)
 GET     /api/project/:id/assetFolderFiles   @controllers.ProjectEntryController.assetFolderFilesList(id:Int, allVersions:Boolean ?=false)
 GET     /api/project/:id                    @controllers.ProjectEntryController.getitem(id: Int)

--- a/frontend/app/DeletionRecords/DeletionRecord.tsx
+++ b/frontend/app/DeletionRecords/DeletionRecord.tsx
@@ -1,0 +1,133 @@
+import React, { useEffect, useState } from "react";
+import { RouteComponentProps } from "react-router-dom";
+import { Paper, Grid } from "@material-ui/core";
+import { useGuardianStyles } from "~/misc/utils";
+import { getItemsNotDeleted, getDeleteJob } from "../ProjectEntryList/helpers";
+import { Helmet } from "react-helmet";
+import { isLoggedIn } from "~/utils/api";
+
+interface DeletionRecordStateTypes {
+  projectEntry?: string;
+}
+
+type DeletionRecordProps = RouteComponentProps<DeletionRecordStateTypes>;
+
+const DeletionRecord: React.FC<DeletionRecordProps> = (props) => {
+  const classes = useGuardianStyles();
+
+  const [deleteJobStatus, setDeleteJobStatus] = useState<string>("");
+  const [itemsNotDeleted, setItemsNotDeleted] = useState<ItemsNotDeleted[]>([]);
+  const [refreshInterval, setRefreshInterval] = useState<any>();
+  const [isAdmin, setIsAdmin] = useState<boolean>(false);
+
+  const getDeleteItemData = async () => {
+    try {
+      const id = Number(props.match.params.projectEntry);
+      const returnedItems = await getItemsNotDeleted(id);
+      setItemsNotDeleted(returnedItems);
+    } catch {
+      console.log("Could not load items that where not deleted.");
+    }
+  };
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchWhoIsLoggedIn = async () => {
+      try {
+        const loggedIn = await isLoggedIn();
+        setIsAdmin(loggedIn.isAdmin);
+      } catch {
+        setIsAdmin(false);
+      }
+    };
+
+    fetchWhoIsLoggedIn();
+
+    const getDeleteJobData = async () => {
+      try {
+        const id = Number(props.match.params.projectEntry);
+        const returnedStatus = await getDeleteJob(id);
+        setDeleteJobStatus(returnedStatus);
+      } catch {
+        console.log("Could not load delete job status.");
+      }
+    };
+
+    getDeleteJobData();
+
+    const interval = setInterval(() => getDeleteJobData(), 10000);
+    setRefreshInterval(interval);
+
+    getDeleteItemData();
+
+    return () => {
+      isMounted = false;
+      clearInterval(interval);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (deleteJobStatus == "Finished") {
+      getDeleteItemData();
+      clearInterval(refreshInterval);
+    }
+  }, [deleteJobStatus]);
+
+  return (
+    <>
+      <Helmet>
+        <title>
+          Deletion Record for Project {props.match.params.projectEntry} - Pluto
+          Admin
+        </title>
+      </Helmet>
+      {isAdmin ? (
+        <Paper className={classes.root} elevation={3}>
+          <Grid container xs={12} direction="row" spacing={3}>
+            <Grid item xs={12} style={{ fontSize: "2em" }}>
+              Project {props.match.params.projectEntry} Deletion Record
+            </Grid>
+            <Grid item xs={12} style={{ fontSize: "1.6em" }}>
+              Storage Area Network Data Outcome
+            </Grid>
+            <Grid item xs={12}>
+              {deleteJobStatus == "Started" ? <>Job running...</> : null}
+              {deleteJobStatus == "Finished" ? (
+                <>
+                  Deletion instructions sent to RabbitMQ.
+                  {itemsNotDeleted.length > 0 ? (
+                    <>
+                      <br />
+                      <br />
+                      No attempt to delete the following items was made due to
+                      them being in more than one project:-
+                      <br />
+                    </>
+                  ) : null}
+                  {itemsNotDeleted
+                    ? itemsNotDeleted.map((vidispine_item) => {
+                        const { id, projectEntry, item } = vidispine_item;
+                        return (
+                          <>
+                            <a href={"/vs/item/" + item} target="_blank">
+                              {item}
+                            </a>
+                            <br />
+                          </>
+                        );
+                      })
+                    : null}
+                </>
+              ) : null}
+            </Grid>
+          </Grid>
+        </Paper>
+      ) : (
+        <div>You do not have access to this page.</div>
+      )}
+    </>
+  );
+};
+
+export default DeletionRecord;

--- a/frontend/app/DeletionRecords/DeletionRecords.tsx
+++ b/frontend/app/DeletionRecords/DeletionRecords.tsx
@@ -1,0 +1,156 @@
+import React, { useEffect, useState } from "react";
+import { RouteComponentProps } from "react-router-dom";
+import {
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  TableContainer,
+  Paper,
+  TablePagination,
+  TableSortLabel,
+} from "@material-ui/core";
+import { getDeletionRecordsOnPage } from "./helpers";
+import { sortListByOrder, SortDirection } from "../utils/lists";
+import { isLoggedIn } from "../utils/api";
+import { Helmet } from "react-helmet";
+import { useGuardianStyles } from "~/misc/utils";
+
+const tableHeaderTitles: HeaderTitle<DeletionRecord>[] = [
+  { label: "Idenity", key: "id" },
+  { label: "Project", key: "projectEntry" },
+  { label: "Status", key: "status" },
+];
+
+const pageSizeOptions = [25, 50, 100];
+
+const DeletionRecords: React.FC<RouteComponentProps> = (props) => {
+  const classes = useGuardianStyles();
+
+  const [deletionRecords, setDeletionRecords] = useState<DeletionRecord[]>([]);
+  const [isAdmin, setIsAdmin] = useState<boolean>(false);
+  const [page, setPage] = useState(0);
+  const [pageSize, setRowsPerPage] = useState(pageSizeOptions[0]);
+  const [order, setOrder] = useState<SortDirection>("asc");
+  const [orderBy, setOrderBy] = useState<keyof DeletionRecord>("id");
+
+  useEffect(() => {
+    const fetchDeletionRecordsOnPage = async () => {
+      const workingGroups = await getDeletionRecordsOnPage({ page, pageSize });
+      setDeletionRecords(workingGroups);
+    };
+
+    const fetchWhoIsLoggedIn = async () => {
+      try {
+        const loggedIn = await isLoggedIn();
+        setIsAdmin(loggedIn.isAdmin);
+      } catch {
+        setIsAdmin(false);
+      }
+    };
+
+    fetchWhoIsLoggedIn();
+
+    fetchDeletionRecordsOnPage();
+  }, [page, pageSize]);
+
+  const handleChangePage = (
+    _event: React.MouseEvent<HTMLButtonElement, MouseEvent> | null,
+    newPage: number
+  ) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = async (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setRowsPerPage(+event.target.value);
+    setPage(0);
+  };
+
+  const sortByColumn = (property: keyof DeletionRecord) => (
+    _event: React.MouseEvent<unknown>
+  ) => {
+    const isAsc = orderBy === property && order === "asc";
+    setOrder(isAsc ? "desc" : "asc");
+    setOrderBy(property);
+  };
+
+  return (
+    <>
+      <Helmet>
+        <title>Deletion Records - Pluto Admin</title>
+      </Helmet>
+      {isAdmin ? (
+        <Paper elevation={3}>
+          <TableContainer>
+            <Table className={classes.table}>
+              <TableHead>
+                <TableRow>
+                  {tableHeaderTitles.map((title, index) => (
+                    <TableCell
+                      key={title.label ? title.label : index}
+                      sortDirection={orderBy === title.key ? order : false}
+                    >
+                      {title.key ? (
+                        <TableSortLabel
+                          active={orderBy === title.key}
+                          direction={orderBy === title.key ? order : "asc"}
+                          onClick={sortByColumn(title.key)}
+                        >
+                          {title.label}
+                          {orderBy === title.key && (
+                            <span className={classes.visuallyHidden}>
+                              {order === "desc"
+                                ? "sorted descending"
+                                : "sorted ascending"}
+                            </span>
+                          )}
+                        </TableSortLabel>
+                      ) : (
+                        title.label
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {sortListByOrder(deletionRecords, orderBy, order).map(
+                  ({ id, projectEntry, status }) => (
+                    <TableRow
+                      hover={true}
+                      onClick={() =>
+                        props.history.push(`/deleted/${projectEntry}`)
+                      }
+                      key={id}
+                    >
+                      <TableCell>{id}</TableCell>
+                      <TableCell>{projectEntry}</TableCell>
+                      <TableCell>{status}</TableCell>
+                    </TableRow>
+                  )
+                )}
+              </TableBody>
+            </Table>
+          </TableContainer>
+
+          <TablePagination
+            rowsPerPageOptions={pageSizeOptions}
+            component="div"
+            count={-1}
+            rowsPerPage={pageSize}
+            page={page}
+            onPageChange={handleChangePage}
+            onRowsPerPageChange={handleChangeRowsPerPage}
+            labelDisplayedRows={({ from, to }) => `${from}-${to}`}
+          />
+        </Paper>
+      ) : (
+        <div>You do not have access to this page.</div>
+      )}
+    </>
+  );
+};
+
+export default DeletionRecords;

--- a/frontend/app/DeletionRecords/helpers.ts
+++ b/frontend/app/DeletionRecords/helpers.ts
@@ -1,0 +1,33 @@
+import Axios from "axios";
+
+const API = "/api/project";
+const API_DELETED = `${API}/deleted`;
+
+interface DeletionRecordsOnPage {
+  page?: number;
+  pageSize?: number;
+}
+
+export const getDeletionRecordsOnPage = async ({
+  page = 0,
+  pageSize = 25,
+}): Promise<DeletionRecord[]> => {
+  try {
+    const {
+      status,
+      data: { result },
+    } = await Axios.get<PlutoApiResponse<DeletionRecord[]>>(
+      `${API_DELETED}?startAt=${page * pageSize}&length=${pageSize}`
+    );
+
+    if (status === 200) {
+      console.log(result);
+      return result;
+    }
+
+    throw new Error(`Could not retrieve deletion records. ${status}`);
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};

--- a/frontend/app/index.jsx
+++ b/frontend/app/index.jsx
@@ -67,6 +67,8 @@ import VersionTranslationsList from "./PremiereVersionTranslation/VersionTransla
 import ProjectDeleteDataComponent from "./ProjectEntryList/ProjectDeleteDataComponent";
 import CommissionDeleteDataComponent from "./CommissionsList/CommissionDeleteDataComponent";
 import AssetFolderProjectBackups from "./ProjectEntryList/AssetFolderProjectBackups";
+import DeletionRecords from "./DeletionRecords/DeletionRecords.tsx";
+import DeletionRecord from "./DeletionRecords/DeletionRecord.tsx";
 
 library.add(faSearch);
 
@@ -394,7 +396,11 @@ class App extends React.Component {
                     />
                     <Route path="/postrun/" component={PostrunList} />
                     <Route path="/defaults/" component={ServerDefaults} />
-
+                    <Route
+                      path="/deleted/:projectEntry"
+                      component={DeletionRecord}
+                    />
+                    <Route path="/deleted/" component={DeletionRecords} />
                     <Route
                       exact
                       path="/"

--- a/frontend/types/types.d.ts
+++ b/frontend/types/types.d.ts
@@ -383,3 +383,9 @@ interface AssetFolderProjectFilesResponse {
   status: string;
   files: AssetFolderFileEntry[];
 }
+
+interface DeletionRecord {
+  id: number;
+  projectEntry: number;
+  status: string;
+}


### PR DESCRIPTION
## What does this change?

Adds persistent deletion records.

## How can we measure success?

Deletion records can be accessed by administrators even if the project record has been deleted.

## Images

![PC111](https://github.com/guardian/pluto-core/assets/10620802/40014bde-f418-4c21-a070-4dffe66e2600)

![PC112](https://github.com/guardian/pluto-core/assets/10620802/1f9ea921-fb71-4ea9-8be8-4126bf0e5eb2)

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.