### PR TITLE
Commission edit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: all set-env build-frontend build-backend localrestart
+
+all: set-env build-frontend build-backend localrestart
+
+set-env:
+	@echo "Setting up environment"
+	eval $(minikube docker-env)
+
+build-frontend:
+	cd frontend && yarn build
+
+build-backend:
+	sbt docker:publishLocal
+
+localrestart:
+	kubectl delete pod -l service=pluto-core

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ $ sbt docker:publishLocal
 ```
 - this should create a local docker image called `guardianmultimedia/pluto-core:DEV`.  If done from the minikube context it will immediately be available for use in the cluster.
 
+Alternatively, run `$ make` in the root of the project. The supplied `Makefile` 
+1. Ensures you are using the minikube docker context
+2. Builds the frontend
+3. Builds backend and publishes a local image
+4. Deletes the old pluto-core pod so you can test the new image 
+
 ## Session cookie setup
 
 pluto-core is still under active development and still uses a session cookie. This is controlled by the `play.http.session` section of `application.conf`.

--- a/frontend/app/CommissionsList/CommissionEntryEditComponent.tsx
+++ b/frontend/app/CommissionsList/CommissionEntryEditComponent.tsx
@@ -85,57 +85,6 @@ const CommissionEntryForm: React.FC<CommissionEntryFormProps> = ({
   const hasUnsavedChanges =
     JSON.stringify(formState) !== JSON.stringify(commission);
 
-  const [
-    initialCommission,
-    setInitialCommission,
-  ] = useState<CommissionFullRecord | null>(null);
-
-  // const [hasChanges, setHasChanges] = React.useState(false);
-  // const fieldValueChanged = (
-  //   value: string | null,
-  //   field: keyof CommissionFullRecord
-  // ): void => {
-  //   const updatedCommission = { ...props.commission, [field]: value };
-  //   props.onChange(updatedCommission);
-  //   console.log("Updated commission: ", updatedCommission);
-  //   console.log("Initial Commission: ", initialCommission);
-  //   setHasChanges(
-  //     JSON.stringify(updatedCommission) !== JSON.stringify(initialCommission)
-  //   );
-  // };
-
-  // const fieldChanged = (
-  //   event: React.ChangeEvent<
-  //     | HTMLTextAreaElement
-  //     | HTMLInputElement
-  //     | HTMLSelectElement
-  //     | { name?: string; value: string }
-  //   >,
-  //   field: keyof CommissionFullRecord,
-  //   value?: string | null
-  // ): void => {
-  //   console.log("Field changed: ", field);
-  //   // If a value is provided directly, use it; otherwise, fall back to event.target.value
-  //   const fieldValue = value !== undefined ? value : event.target.value;
-  //   fieldValueChanged(fieldValue, field);
-  // };
-
-  // useEffect(() => {
-  //   if (initialCommission === null) {
-  //     setInitialCommission(props.commission);
-  //   }
-  // }, [props.commission]);
-
-  // let createdTime: string | undefined = undefined;
-  // let timeValue;
-  // try {
-  //   timeValue = ParseDateISO(props.commission.created);
-  //   createdTime = FormatDate(timeValue, "E do MMM yyyy, h:mm a");
-  // } catch (err) {
-  //   console.warn("Invalid creation time ", props.commission.created, ": ", err);
-  //   console.warn("timeValue was ", timeValue);
-  // }
-
   return (
     <form onSubmit={handleSubmit} className={classes.root}>
       <Grid container xs={12} direction="row" spacing={3}>

--- a/frontend/app/CommissionsList/CommissionEntryEditComponent.tsx
+++ b/frontend/app/CommissionsList/CommissionEntryEditComponent.tsx
@@ -24,6 +24,10 @@ import {
 import Snackbar from "@material-ui/core/Snackbar";
 import Alert from "@material-ui/lab/Alert";
 import {
+  SystemNotification,
+  SystemNotifcationKind,
+} from "@guardian/pluto-headers";
+import {
   KeyboardDatePicker,
   MuiPickersUtilsProvider,
 } from "@material-ui/pickers";
@@ -120,7 +124,13 @@ const CommissionEntryForm: React.FC<CommissionEntryFormProps> = (props) => {
   }
 
   return (
-    <form onSubmit={props.onSubmit} className={classes.root}>
+    <form
+      onSubmit={(evt) => {
+        evt.preventDefault(); // Prevent the default form submission
+        props.onSubmit(evt); // Call the onSubmit prop function
+      }}
+      className={classes.root}
+    >
       <Grid container xs={12} direction="row" spacing={3}>
         {/*left-hand column*/}
         <Grid item xs={6}>
@@ -456,15 +466,6 @@ const CommissionEntryEditComponent: React.FC<RouteComponentProps<
 
   return (
     <>
-      <Snackbar
-        open={openSnackbar}
-        autoHideDuration={6000}
-        onClose={() => setOpenSnackbar(false)}
-      >
-        <Alert onClose={() => setOpenSnackbar(false)} severity="success">
-          {snackbarMessage}
-        </Alert>
-      </Snackbar>
       {commissionData ? (
         <Helmet>
           <title>[{commissionData.title}] Details</title>
@@ -537,26 +538,24 @@ const CommissionEntryEditComponent: React.FC<RouteComponentProps<
             workingGroupName="test"
             isSaving={isSaving}
             onSubmit={(evt) => {
-              setIsSaving(true);
-              console.log(
-                "Commission saved successfully - snackbar should render"
-              );
-              setTimeout(() => {
-                // Navigate or update state to cause re-render
-              }, 12000);
-              console.log(
-                "Commission saved successfully - snackbar should render"
-              );
-              setSnackbarMessage("Commission saved successfully!"); // Set success message
-              setOpenSnackbar(true);
+              // setIsSaving(true);
 
               updateCommissionData(commissionData)
                 .then(() => {
                   setIsSaving(false);
-                  handleSaveSuccess();
+                  SystemNotification.open(
+                    SystemNotifcationKind.Success,
+                    `Successfully updated Commission ${commissionData.title}`
+                  );
+                  // history.goBack();
                 })
                 .catch((err) => {
                   setIsSaving(false);
+                  SystemNotification.open(
+                    SystemNotifcationKind.Error,
+                    `Failed to update Commission "${commissionData.title}". Please try again.`
+                  ); // Display error message
+                  console.error("Error updating commission: ", err);
                   if (err.hasOwnProperty("response")) {
                     console.error(
                       "Server error saving record: ",

--- a/frontend/app/CommissionsList/CommissionEntryEditComponent.tsx
+++ b/frontend/app/CommissionsList/CommissionEntryEditComponent.tsx
@@ -21,6 +21,8 @@ import {
   InputLabel,
   Box,
 } from "@material-ui/core";
+import Snackbar from "@material-ui/core/Snackbar";
+import Alert from "@material-ui/lab/Alert";
 import {
   KeyboardDatePicker,
   MuiPickersUtilsProvider,
@@ -265,11 +267,32 @@ const CommissionEntryEditComponent: React.FC<RouteComponentProps<
   const [projectList, setProjectList] = useState<Project[] | undefined>(
     undefined
   );
+
+  const [openSnackbar, setOpenSnackbar] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState("");
+  const handleSaveSuccess = () => {
+    setSnackbarMessage("Commission saved successfully!");
+    setOpenSnackbar(true);
+  };
+  const history = useHistory();
+
+  useEffect(() => {
+    if (openSnackbar) {
+      const timer = setTimeout(() => {
+        // Perform delayed actions here, like navigation or updating state
+        // history.push("/some-path"); // Example navigation (if needed)
+
+        setOpenSnackbar(false); // Close the Snackbar after the delay
+      }, 12000); // Delay in milliseconds
+
+      return () => clearTimeout(timer); // Cleanup the timer on component unmount or when Snackbar closes
+    }
+  }, [openSnackbar, history]);
+
   const [lastError, setLastError] = useState<null | string>(null);
   const [isSaving, setIsSaving] = useState<boolean>(false);
 
   const classes = useGuardianStyles();
-  const history = useHistory();
   const [errorDialog, setErrorDialog] = useState<boolean>(false);
   const [filterTerms, setFilterTerms] = useState<ProjectFilterTerms>({
     commissionId: parseInt(props.match.params.commissionId),
@@ -433,6 +456,15 @@ const CommissionEntryEditComponent: React.FC<RouteComponentProps<
 
   return (
     <>
+      <Snackbar
+        open={openSnackbar}
+        autoHideDuration={6000}
+        onClose={() => setOpenSnackbar(false)}
+      >
+        <Alert onClose={() => setOpenSnackbar(false)} severity="success">
+          {snackbarMessage}
+        </Alert>
+      </Snackbar>
       {commissionData ? (
         <Helmet>
           <title>[{commissionData.title}] Details</title>
@@ -505,12 +537,23 @@ const CommissionEntryEditComponent: React.FC<RouteComponentProps<
             workingGroupName="test"
             isSaving={isSaving}
             onSubmit={(evt) => {
-              evt.preventDefault();
               setIsSaving(true);
+              console.log(
+                "Commission saved successfully - snackbar should render"
+              );
+              setTimeout(() => {
+                // Navigate or update state to cause re-render
+              }, 12000);
+              console.log(
+                "Commission saved successfully - snackbar should render"
+              );
+              setSnackbarMessage("Commission saved successfully!"); // Set success message
+              setOpenSnackbar(true);
+
               updateCommissionData(commissionData)
                 .then(() => {
                   setIsSaving(false);
-                  history.push("/commission");
+                  handleSaveSuccess();
                 })
                 .catch((err) => {
                   setIsSaving(false);


### PR DESCRIPTION
- After editing a commission and clicking the SAVE CHANGES button, the user is notified if the save was successful. 
- The user is not redirected away from the edit commission page when saving changes.
- `Makefile` added for quicker local development


![Screenshot 2024-03-14 at 13 03 06](https://github.com/guardian/pluto-core/assets/66913730/3626f19b-369a-4458-8cc9-aa9547ceb5cc)
