### PR TITLE
Removing Storage Section

### DIFF
--- a/frontend/app/ProjectEntryList/ProjectEntryEditComponent.tsx
+++ b/frontend/app/ProjectEntryList/ProjectEntryEditComponent.tsx
@@ -489,12 +489,6 @@ const ProjectEntryEditComponent: React.FC<ProjectEntryEditComponentProps> = (
           onError={subComponentErrored}
         />
       )}
-      {project === EMPTY_PROJECT ? null : (
-        <ProjectEntryVaultComponent
-          project={project}
-          onError={subComponentErrored}
-        />
-      )}
       <Dialog
         open={errorDialog}
         onClose={closeDialog}


### PR DESCRIPTION
## What does this change?

Removes the storage section from project pages.

## How can we measure success?

The broken storage section no longer displays.

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.