### PR TITLE
Display Data on Missing Files

### DIFF
--- a/app/controllers/MissingFilesController.scala
+++ b/app/controllers/MissingFilesController.scala
@@ -15,7 +15,7 @@ import scala.util.{Failure, Success}
 @Singleton
 class MissingFilesController @Inject()(cc:ControllerComponents, override val bearerTokenAuth:BearerTokenAuth,
                                        override implicit val config: Configuration,
-                                       dbConfigProvider: DatabaseConfigProvider, cacheImpl:SyncCacheApi)
+                                       dbConfigProvider: DatabaseConfigProvider, cacheImpl:SyncCacheApi, missingAssetFileEntryDAO: MissingAssetFileEntryDAO)
   extends AbstractController(cc) with Security with MissingAssetFileEntrySerializer {
   override val logger = Logger(getClass)
 
@@ -27,6 +27,19 @@ class MissingFilesController @Inject()(cc:ControllerComponents, override val bea
       case Success(results)=>Ok(Json.obj("status"->"ok","results"->results))
       case Failure(error)=>
         logger.error("Could not list missing files: ", error)
+        InternalServerError(Json.obj("status"->"error","detail"->error.toString))
+    })
+  }}
+
+  def removeWarning(project:Int) = IsAuthenticatedAsync {uid=>{request=>
+    MissingAssetFileEntryDAO.getRecords(project).map({
+      case Success(results)=>
+        results.map(record =>
+          missingAssetFileEntryDAO.deleteRecord(record)
+        )
+        Ok(Json.obj("status"->"ok"))
+      case Failure(error)=>
+        logger.error("Could not delete missing file records: ", error)
         InternalServerError(Json.obj("status"->"error","detail"->error.toString))
     })
   }}

--- a/conf/routes
+++ b/conf/routes
@@ -66,6 +66,7 @@ GET     /api/project/:id/deleteItems        @controllers.ItemDeleteDataControlle
 GET     /api/project/:id/matrixDeleteJob    @controllers.ProjectEntryController.matrixDeleteJob(id: Int)
 GET     /api/project/:id/matrixDeleteItems  @controllers.MatrixDeleteDataController.listForProject(id: Int)
 GET     /api/project/:id/missingFiles       @controllers.MissingFilesController.missing(id:Int)
+GET     /api/project/:id/removeWarning      @controllers.MissingFilesController.removeWarning(id:Int)
 
 GET     /api/valid-users                    @controllers.ProjectEntryController.queryUsersForAutocomplete(prefix:String ?= "", limit:Option[Int])
 GET     /api/known-user                     @controllers.ProjectEntryController.isUserKnown(uname:String ?= "")

--- a/frontend/app/ProjectEntryList/ProjectEntryEditComponent.tsx
+++ b/frontend/app/ProjectEntryList/ProjectEntryEditComponent.tsx
@@ -281,6 +281,23 @@ const ProjectEntryEditComponent: React.FC<ProjectEntryEditComponentProps> = (
     }
   };
 
+  const removeWarning = async (project: number) => {
+    try {
+      const response = await axios.get(`/api/project/${project}/removeWarning`);
+      console.log("Attempt to remove warning got ", response.data);
+      SystemNotification.open(
+        SystemNotifcationKind.Success,
+        `Successfully started attempt at removing warning.`
+      );
+    } catch (err) {
+      console.error("Could not remove warning: ", err);
+      SystemNotification.open(
+        SystemNotifcationKind.Error,
+        `Failed to start attempt at removing warning.`
+      );
+    }
+  };
+
   return (
     <>
       {project ? (
@@ -502,6 +519,56 @@ const ProjectEntryEditComponent: React.FC<ProjectEntryEditComponentProps> = (
           project={project}
           onError={subComponentErrored}
         />
+      )}
+      {missingFiles.length === 0 ? null : (
+        <Paper
+          className={classes.root}
+          elevation={3}
+          style={{ marginTop: "1rem" }}
+        >
+          <Grid container xs={12} direction="row" spacing={3}>
+            <Grid item xs={8}>
+              <Typography variant="h4">Warning</Typography>
+            </Grid>
+            <Grid item xs={4}>
+              <Button
+                style={{
+                  width: "180px",
+                }}
+                onClick={async () => {
+                  try {
+                    await removeWarning(project.id);
+                    getMissingFilesData();
+                  } catch (error) {
+                    SystemNotification.open(
+                      SystemNotifcationKind.Error,
+                      `An error occurred when attempting to remove the warning.`
+                    );
+                    console.error(error);
+                  }
+                }}
+                variant="contained"
+              >
+                Remove&nbsp;Warning
+              </Button>
+            </Grid>
+            <Grid item xs={12}>
+              <Typography>
+                Some media files used in this project have been imported from
+                Internet Downloads or other areas. Please move these files to
+                the project's asset folder, otherwise these files will be lost.
+                <br />
+                <br />
+                {missingFiles.map((file, index) => (
+                  <>
+                    {file.filepath}
+                    <br />
+                  </>
+                ))}
+              </Typography>
+            </Grid>
+          </Grid>
+        </Paper>
       )}
       <Dialog
         open={errorDialog}


### PR DESCRIPTION
## What does this change?

Adds display of data on files found in the project that are not in the asset folder.

## How can we measure success?

The recorded missing file data is displayed in the interface.

## Images

![PC116](https://github.com/guardian/pluto-core/assets/10620802/3388f798-5b08-4d10-acfd-6032f83f4375)

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.