### PR TITLE
Ban Setting the Project Status to Completed if There Are Missing Files

### DIFF
--- a/frontend/app/ProjectEntryList/ProjectEntryEditComponent.tsx
+++ b/frontend/app/ProjectEntryList/ProjectEntryEditComponent.tsx
@@ -222,20 +222,45 @@ const ProjectEntryEditComponent: React.FC<ProjectEntryEditComponentProps> = (
     }
 
     if (project.title) {
-      try {
-        await updateProject(project as Project);
+      if (project.status == "Completed") {
+        if (missingFiles.length == 0) {
+          try {
+            await updateProject(project as Project);
 
-        SystemNotification.open(
-          SystemNotifcationKind.Success,
-          `Successfully updated Project "${project.title}"`
-        );
-        history.goBack();
-        setInitialProject({ ...project });
-      } catch {
-        SystemNotification.open(
-          SystemNotifcationKind.Error,
-          `Failed to update Project "${project.title}"`
-        );
+            SystemNotification.open(
+              SystemNotifcationKind.Success,
+              `Successfully updated project "${project.title}"`
+            );
+            history.goBack();
+            setInitialProject({ ...project });
+          } catch {
+            SystemNotification.open(
+              SystemNotifcationKind.Error,
+              `Failed to update project "${project.title}"`
+            );
+          }
+        } else {
+          SystemNotification.open(
+            SystemNotifcationKind.Error,
+            `Cannot change project "${project.title}" status to Completed because it has missing files.`
+          );
+        }
+      } else {
+        try {
+          await updateProject(project as Project);
+
+          SystemNotification.open(
+            SystemNotifcationKind.Success,
+            `Successfully updated project "${project.title}"`
+          );
+          history.goBack();
+          setInitialProject({ ...project });
+        } catch {
+          SystemNotification.open(
+            SystemNotifcationKind.Error,
+            `Failed to update project "${project.title}"`
+          );
+        }
       }
     }
   };


### PR DESCRIPTION
## What does this change?

Stops users setting the status of projects with one or more missing files to Completed.

## How can we measure success?

Users should not be able to set files to Completed if they have at least on missing file.

## Images

![Screenshot 2024-05-01 at 16 33 29](https://github.com/guardian/pluto-core/assets/10620802/e23e4727-c650-42c1-a51e-959d796f08b6)

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.