### PR TITLE
Download Button for Project Files

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -67,6 +67,7 @@ GET     /api/project/:id/matrixDeleteJob    @controllers.ProjectEntryController.
 GET     /api/project/:id/matrixDeleteItems  @controllers.MatrixDeleteDataController.listForProject(id: Int)
 GET     /api/project/:id/missingFiles       @controllers.MissingFilesController.missing(id:Int)
 GET     /api/project/:id/removeWarning      @controllers.MissingFilesController.removeWarning(id:Int)
+GET     /api/project/:id/fileDownload       @controllers.ProjectEntryController.fileDownload(id:Int)
 
 GET     /api/valid-users                    @controllers.ProjectEntryController.queryUsersForAutocomplete(prefix:String ?= "", limit:Option[Int])
 GET     /api/known-user                     @controllers.ProjectEntryController.isUserKnown(uname:String ?= "")

--- a/frontend/app/ProjectEntryList/ProjectEntryEditComponent.tsx
+++ b/frontend/app/ProjectEntryList/ProjectEntryEditComponent.tsx
@@ -24,7 +24,7 @@ import {
   updateProjectOpenedStatus,
   getSimpleProjectTypeData,
   getMissingFiles,
-  downloadProjectFile
+  downloadProjectFile,
 } from "./helpers";
 import {
   SystemNotification,
@@ -445,30 +445,31 @@ const ProjectEntryEditComponent: React.FC<ProjectEntryEditComponentProps> = (
                 {projectTypeData[project.projectTypeId] == "Premiere" ? (
                   <ProjectFileUpload projectId={project.id}></ProjectFileUpload>
                 ) : null}
-                {projectTypeData[project.projectTypeId] == ("Premiere" || "After Effects" || "Prelude") ? (
-                    <Tooltip title="Press this button to download the project file.">
-                      <Button
-                          style={{
-                            marginLeft: "14px",
-                            marginRight: "8px",
-                            minWidth: "170px",
-                          }}
-                          variant="contained"
-                          onClick={async () => {
-                            try {
-                              await downloadProjectFile(project.id);
-                            } catch (error) {
-                              SystemNotification.open(
-                                  SystemNotifcationKind.Error,
-                                  `An error occurred when attempting to download the project file.`
-                              );
-                              console.error(error);
-                            }
-                          }}
-                      >
-                        Download&nbsp;Project&nbsp;File
-                      </Button>
-                    </Tooltip>
+                {projectTypeData[project.projectTypeId] ==
+                ("Premiere" || "After Effects" || "Prelude") ? (
+                  <Tooltip title="Press this button to download the project file.">
+                    <Button
+                      style={{
+                        marginLeft: "14px",
+                        marginRight: "8px",
+                        minWidth: "170px",
+                      }}
+                      variant="contained"
+                      onClick={async () => {
+                        try {
+                          await downloadProjectFile(project.id);
+                        } catch (error) {
+                          SystemNotification.open(
+                            SystemNotifcationKind.Error,
+                            `An error occurred when attempting to download the project file.`
+                          );
+                          console.error(error);
+                        }
+                      }}
+                    >
+                      Download&nbsp;Project&nbsp;File
+                    </Button>
+                  </Tooltip>
                 ) : null}
                 {projectTypeData[project.projectTypeId] == "Audition" ||
                 projectTypeData[project.projectTypeId] == "Cubase" ? (

--- a/frontend/app/ProjectEntryList/ProjectEntryEditComponent.tsx
+++ b/frontend/app/ProjectEntryList/ProjectEntryEditComponent.tsx
@@ -24,6 +24,7 @@ import {
   updateProjectOpenedStatus,
   getSimpleProjectTypeData,
   getMissingFiles,
+  downloadProjectFile
 } from "./helpers";
 import {
   SystemNotification,
@@ -443,6 +444,31 @@ const ProjectEntryEditComponent: React.FC<ProjectEntryEditComponentProps> = (
                 ) : null}
                 {projectTypeData[project.projectTypeId] == "Premiere" ? (
                   <ProjectFileUpload projectId={project.id}></ProjectFileUpload>
+                ) : null}
+                {projectTypeData[project.projectTypeId] == ("Premiere" || "After Effects" || "Prelude") ? (
+                    <Tooltip title="Press this button to download the project file.">
+                      <Button
+                          style={{
+                            marginLeft: "14px",
+                            marginRight: "8px",
+                            minWidth: "170px",
+                          }}
+                          variant="contained"
+                          onClick={async () => {
+                            try {
+                              await downloadProjectFile(project.id);
+                            } catch (error) {
+                              SystemNotification.open(
+                                  SystemNotifcationKind.Error,
+                                  `An error occurred when attempting to download the project file.`
+                              );
+                              console.error(error);
+                            }
+                          }}
+                      >
+                        Download&nbsp;Project&nbsp;File
+                      </Button>
+                    </Tooltip>
                 ) : null}
                 {projectTypeData[project.projectTypeId] == "Audition" ||
                 projectTypeData[project.projectTypeId] == "Cubase" ? (

--- a/frontend/app/ProjectEntryList/ProjectEntryEditComponent.tsx
+++ b/frontend/app/ProjectEntryList/ProjectEntryEditComponent.tsx
@@ -452,7 +452,7 @@ const ProjectEntryEditComponent: React.FC<ProjectEntryEditComponentProps> = (
                       style={{
                         marginLeft: "14px",
                         marginRight: "8px",
-                        minWidth: "170px",
+                        minWidth: "220px",
                       }}
                       variant="contained"
                       onClick={async () => {

--- a/frontend/app/ProjectEntryList/helpers.ts
+++ b/frontend/app/ProjectEntryList/helpers.ts
@@ -581,6 +581,8 @@ export const getMissingFiles = async (id: number): Promise<MissingFiles[]> => {
 };
 
 export const downloadProjectFile = async (id: number) => {
-  const url = `${deploymentRootPath}${API_PROJECTS}/${id}/fileDownload`;
+  const url = `${deploymentRootPath}${API_PROJECTS}/${id}/fileDownload?access_token=${localStorage.getItem(
+    "pluto:access-token"
+  )}`;
   window.open(url);
 };

--- a/frontend/app/ProjectEntryList/helpers.ts
+++ b/frontend/app/ProjectEntryList/helpers.ts
@@ -10,6 +10,8 @@ const API_PROJECTS = `${API}/project`;
 const API_PROJECTS_FILTER = `${API_PROJECTS}/list`;
 const API_FILES = `${API}/file`;
 
+declare var deploymentRootPath: string;
+
 interface ProjectsOnPage {
   page?: number;
   pageSize?: number;
@@ -576,4 +578,9 @@ export const getMissingFiles = async (id: number): Promise<MissingFiles[]> => {
     console.error(error);
     throw error;
   }
+};
+
+export const downloadProjectFile = async (id: number) => {
+  const url = `${deploymentRootPath}${API_PROJECTS}/${id}/fileDownload`;
+  window.open(url);
 };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@types/color": "^3.0.5",
     "@types/enzyme": "^3.10.8",
+    "@types/file-saver": "^2.0.7",
     "@types/jest": "^26.0.22",
     "@types/js-cookie": "^2.2.6",
     "@types/moxios": "^0.4.12",
@@ -57,6 +58,7 @@
     "bl": "4.0.3",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
+    "file-saver": "^2.0.5",
     "husky": ">=4",
     "ini": "1.3.6",
     "jest": "^26.0.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1056,6 +1056,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
 
+"@types/file-saver@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/file-saver/-/file-saver-2.0.7.tgz#8dbb2f24bdc7486c54aa854eb414940bbd056f7d"
+  integrity sha512-dNKVfHd/jk0SkR/exKGj2ggkB45MAkzvWCaqLUUgkyjITkGNzH8H+yUwr+BLJUBjZOe9w8X3wgmXhZDRg1ED6A==
+
 "@types/graceful-fs@^4.1.2":
   version "4.1.8"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.8.tgz#417e461e4dc79d957dc3107f45fe4973b09c2915"
@@ -3306,6 +3311,11 @@ figures@^3.2.0:
   integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
   dependencies:
     escape-string-regexp "^1.0.5"
+
+file-saver@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-2.0.5.tgz#d61cfe2ce059f414d899e9dd6d4107ee25670c38"
+  integrity sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==
 
 fill-range@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## What does this change?

Adds a download button for the project file.

## How can we measure success?

User should be able to download project files from project pages.

## Images

![PC118](https://github.com/guardian/pluto-core/assets/10620802/94bece7f-250b-4cd8-bf61-2247873df504)

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.