### PR TITLE
Server Side Sorting For Project Lists

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -40,7 +40,7 @@ DELETE  /api/template/:id                  @controllers.ProjectTemplateControlle
 
 GET     /api/project                        @controllers.ProjectEntryController.list(startAt:Int ?=0,length:Int ?=100)
 GET     /api/project/list                   @controllers.ProjectEntryController.list(startAt:Int ?=0,length:Int ?=100)
-PUT     /api/project/list                   @controllers.ProjectEntryController.listFiltered(startAt:Int ?=0,length:Int ?=100)
+PUT     /api/project/list                   @controllers.ProjectEntryController.listFilteredAndSorted(startAt:Int ?=0,length:Int ?=100,  sort:String ?="created", sortDirection:String ?="desc")
 OPTIONS /api/project/list                   @controllers.Application.corsOptions
 GET     /api/project/distinctowners         @controllers.ProjectEntryController.distinctOwners
 

--- a/frontend/app/CommissionsList/CommissionDeleteDataComponent.tsx
+++ b/frontend/app/CommissionsList/CommissionDeleteDataComponent.tsx
@@ -110,7 +110,7 @@ const CommissionDeleteDataComponent: React.FC<CommissionDeleteDataComponentProps
         1000,
         filterTerms,
         "desc",
-        "created",
+        "created"
       )
         .then(([projects, count]) => {
           setProjectList(projects);

--- a/frontend/app/CommissionsList/CommissionDeleteDataComponent.tsx
+++ b/frontend/app/CommissionsList/CommissionDeleteDataComponent.tsx
@@ -108,7 +108,9 @@ const CommissionDeleteDataComponent: React.FC<CommissionDeleteDataComponentProps
         Number(props.match.params.commissionId),
         0,
         1000,
-        filterTerms
+        filterTerms,
+        "desc",
+        "created",
       )
         .then(([projects, count]) => {
           setProjectList(projects);

--- a/frontend/app/CommissionsList/CommissionEntryEditComponent.tsx
+++ b/frontend/app/CommissionsList/CommissionEntryEditComponent.tsx
@@ -52,7 +52,7 @@ import ProjectFilterComponent from "~/filter/ProjectFilterComponent";
 import { filterTermsToQuerystring } from "~/filter/terms";
 import { isLoggedIn } from "~/utils/api";
 import { set } from "js-cookie";
-import {SortDirection} from "~/utils/lists";
+import { SortDirection } from "~/utils/lists";
 declare var deploymentRootPath: string;
 
 interface CommissionEntryFormProps {
@@ -640,7 +640,7 @@ const CommissionEntryEditComponent: React.FC<RouteComponentProps<
                     pageSize,
                     filterTerms,
                     order,
-                    orderBy,
+                    orderBy
                   )
                     .then(([projects, count]) => {
                       setProjectList(projects);

--- a/frontend/app/CommissionsList/CommissionEntryEditComponent.tsx
+++ b/frontend/app/CommissionsList/CommissionEntryEditComponent.tsx
@@ -52,6 +52,7 @@ import ProjectFilterComponent from "~/filter/ProjectFilterComponent";
 import { filterTermsToQuerystring } from "~/filter/terms";
 import { isLoggedIn } from "~/utils/api";
 import { set } from "js-cookie";
+import {SortDirection} from "~/utils/lists";
 declare var deploymentRootPath: string;
 
 interface CommissionEntryFormProps {
@@ -278,6 +279,8 @@ const CommissionEntryEditComponent: React.FC<RouteComponentProps<
   >("");
   const [isAdmin, setIsAdmin] = useState<boolean>(false);
   const [userAllowedBoolean, setUserAllowedBoolean] = useState<boolean>(true);
+  const [order, setOrder] = useState<SortDirection>("desc");
+  const [orderBy, setOrderBy] = useState<keyof Project>("created");
 
   useEffect(() => {
     const fetchCommissionData = async () => {
@@ -334,7 +337,7 @@ const CommissionEntryEditComponent: React.FC<RouteComponentProps<
    */
   useEffect(() => {
     const doLoadIn = () => {
-      projectsForCommission(commissionId, 0, 5, filterTerms)
+      projectsForCommission(commissionId, 0, 5, filterTerms, order, orderBy)
         .then(([projects, count]) => {
           setProjectList(projects);
           setProjectCount(count);
@@ -630,12 +633,14 @@ const CommissionEntryEditComponent: React.FC<RouteComponentProps<
               <ProjectsTable
                 className={classes.table}
                 pageSizeOptions={[5, 10, 20]}
-                updateRequired={(page, pageSize) => {
+                updateRequired={(page, pageSize, order, orderBy) => {
                   projectsForCommission(
                     commissionId,
                     page,
                     pageSize,
-                    filterTerms
+                    filterTerms,
+                    order,
+                    orderBy,
                   )
                     .then(([projects, count]) => {
                       setProjectList(projects);

--- a/frontend/app/CommissionsList/helpers.ts
+++ b/frontend/app/CommissionsList/helpers.ts
@@ -129,18 +129,24 @@ export const projectsForCommission: (
   commissionId: number,
   page: number,
   pageSize: number,
-  filterTerms: ProjectFilterTerms
+  filterTerms: ProjectFilterTerms,
+  order: string,
+  orderBy: string | number | symbol
 ) => Promise<[Project[], number]> = async (
   commissionId: number,
   page: number,
   pageSize: number,
-  filterTerms: ProjectFilterTerms
+  filterTerms: ProjectFilterTerms,
+  order: string,
+  orderBy: string | number | symbol
 ) => {
   filterTerms["commissionId"] = commissionId;
   return getProjectsOnPage({
     page: page,
     pageSize: pageSize,
     filterTerms: filterTerms,
+    order: order,
+    orderBy: orderBy,
   });
 };
 

--- a/frontend/app/ProjectEntryList/ProjectEntryList.tsx
+++ b/frontend/app/ProjectEntryList/ProjectEntryList.tsx
@@ -8,7 +8,7 @@ import ProjectsTable from "./ProjectsTable";
 import { Helmet } from "react-helmet";
 import { buildFilterTerms, filterTermsToQuerystring } from "../filter/terms";
 import { useGuardianStyles } from "~/misc/utils";
-import {SortDirection} from "~/utils/lists";
+import { SortDirection } from "~/utils/lists";
 
 const ProjectEntryList: React.FC<RouteComponentProps> = () => {
   // React Router

--- a/frontend/app/ProjectEntryList/ProjectEntryList.tsx
+++ b/frontend/app/ProjectEntryList/ProjectEntryList.tsx
@@ -8,6 +8,7 @@ import ProjectsTable from "./ProjectsTable";
 import { Helmet } from "react-helmet";
 import { buildFilterTerms, filterTermsToQuerystring } from "../filter/terms";
 import { useGuardianStyles } from "~/misc/utils";
+import {SortDirection} from "~/utils/lists";
 
 const ProjectEntryList: React.FC<RouteComponentProps> = () => {
   // React Router
@@ -18,6 +19,8 @@ const ProjectEntryList: React.FC<RouteComponentProps> = () => {
   const [user, setUser] = useState<PlutoUser | null>(null);
   const [pageSize, setPageSize] = useState<number>(25);
   const [page, setPage] = useState<number>(1);
+  const [order, setOrder] = useState<SortDirection>("desc");
+  const [orderBy, setOrderBy] = useState<keyof Project>("created");
   const [projects, setProjects] = useState<Project[]>([]);
   const [projectCount, setProjectCount] = useState<number>(0);
 
@@ -41,6 +44,8 @@ const ProjectEntryList: React.FC<RouteComponentProps> = () => {
       page,
       pageSize,
       filterTerms: filterTerms,
+      order,
+      orderBy,
     });
 
     setProjects(projects);
@@ -51,7 +56,7 @@ const ProjectEntryList: React.FC<RouteComponentProps> = () => {
     if (filterTerms) {
       fetchProjectsOnPage();
     }
-  }, [filterTerms, page, pageSize]);
+  }, [filterTerms, page, pageSize, order, orderBy]);
 
   useEffect(() => {
     const fetchWhoIsLoggedIn = async () => {
@@ -144,10 +149,12 @@ const ProjectEntryList: React.FC<RouteComponentProps> = () => {
         <ProjectsTable
           className={classes.table}
           pageSizeOptions={[25, 50, 100]}
-          updateRequired={(page, pageSize) => {
+          updateRequired={(page, pageSize, order, orderBy) => {
             console.log("ProjectsTable updateRequired");
             setPageSize(pageSize);
             setPage(page);
+            setOrder(order);
+            setOrderBy(orderBy);
           }}
           projects={projects}
           projectCount={projectCount}

--- a/frontend/app/ProjectEntryList/ProjectsTable.tsx
+++ b/frontend/app/ProjectEntryList/ProjectsTable.tsx
@@ -77,7 +77,12 @@ interface ProjectsTableProps {
   //array of page sizes to present to the user
   pageSizeOptions: number[];
   //callback to tell the parent to update the source data
-  updateRequired: (page: number, pageSize: number, order: SortDirection, orderBy: keyof Project) => void;
+  updateRequired: (
+    page: number,
+    pageSize: number,
+    order: SortDirection,
+    orderBy: keyof Project
+  ) => void;
   //list of projects to display
   projects: Project[];
   //is the user an admin
@@ -363,7 +368,12 @@ const ProjectsTable: React.FC<ProjectsTableProps> = (props) => {
                           try {
                             await updateProjectOpenedStatus(id);
 
-                            await props.updateRequired(page, rowsPerPage, order, orderBy);
+                            await props.updateRequired(
+                              page,
+                              rowsPerPage,
+                              order,
+                              orderBy
+                            );
                           } catch (error) {
                             console.error(error);
                           }

--- a/frontend/app/ProjectEntryList/ProjectsTable.tsx
+++ b/frontend/app/ProjectEntryList/ProjectsTable.tsx
@@ -77,7 +77,7 @@ interface ProjectsTableProps {
   //array of page sizes to present to the user
   pageSizeOptions: number[];
   //callback to tell the parent to update the source data
-  updateRequired: (page: number, pageSize: number) => void;
+  updateRequired: (page: number, pageSize: number, order: SortDirection, orderBy: keyof Project) => void;
   //list of projects to display
   projects: Project[];
   //is the user an admin
@@ -105,7 +105,7 @@ const ProjectsTable: React.FC<ProjectsTableProps> = (props) => {
 
   useEffect(() => {
     console.log("filter terms or search changed, updating...");
-    props.updateRequired(page, rowsPerPage);
+    props.updateRequired(page, rowsPerPage, order, orderBy);
   }, [page, rowsPerPage, order, orderBy, refreshGeneration]);
 
   const handleChangePage = (
@@ -270,7 +270,7 @@ const ProjectsTable: React.FC<ProjectsTableProps> = (props) => {
             </TableRow>
           </TableHead>
           <TableBody>
-            {sortListByOrder(props.projects, orderBy, order).map((project) => {
+            {props.projects.map((project) => {
               const {
                 id,
                 title,
@@ -363,7 +363,7 @@ const ProjectsTable: React.FC<ProjectsTableProps> = (props) => {
                           try {
                             await updateProjectOpenedStatus(id);
 
-                            await props.updateRequired(page, rowsPerPage);
+                            await props.updateRequired(page, rowsPerPage, order, orderBy);
                           } catch (error) {
                             console.error(error);
                           }

--- a/frontend/app/ProjectEntryList/helpers.ts
+++ b/frontend/app/ProjectEntryList/helpers.ts
@@ -17,6 +17,8 @@ interface ProjectsOnPage {
   page?: number;
   pageSize?: number;
   filterTerms?: FilterTerms;
+  order?: string;
+  orderBy?: string | number | symbol;
 }
 
 interface PlutoFilesAPIResponse<T> {
@@ -39,6 +41,8 @@ export const getProjectsOnPage = async ({
   page = 0,
   pageSize = 25,
   filterTerms,
+  order,
+  orderBy,
 }: ProjectsOnPage): Promise<[Project[], number]> => {
   try {
     const {
@@ -49,7 +53,7 @@ export const getProjectsOnPage = async ({
       ? await Axios.put<PlutoApiResponseWithCount<Project[]>>(
           `${API_PROJECTS_FILTER}?startAt=${
             page * pageSize
-          }&length=${pageSize}`,
+          }&length=${pageSize}&sort=${String(orderBy)}&sortDirection=${order}`,
           filterTerms
         )
       : await Axios.get<PlutoApiResponseWithCount<Project[]>>(


### PR DESCRIPTION
## What does this change?

Moves project list sorting from the client to the server.

## How can we measure success?

Project lists are now sorted on the server side.

## Images

![Screenshot 2024-06-19 at 12 19 28](https://github.com/guardian/pluto-core/assets/10620802/a769c9e2-17d9-4b9e-a0eb-6175b3f4a200)

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.