### PR TITLE
Making Some Text Larger

### DIFF
--- a/frontend/app/multistep/commissioncreate_new/CommissionTitleComponent.tsx
+++ b/frontend/app/multistep/commissioncreate_new/CommissionTitleComponent.tsx
@@ -64,8 +64,11 @@ const CommissionTitleComponent: React.FC<CommissionTitleComponentProps> = (
                   }
                 }}
                 value={props.title}
-                FormHelperTextProps={{style: {fontSize: "0.86rem"}}}
-                InputLabelProps={{ shrink: true, style: { fontSize: "1.2rem" } }}
+                FormHelperTextProps={{ style: { fontSize: "0.86rem" } }}
+                InputLabelProps={{
+                  shrink: true,
+                  style: { fontSize: "1.2rem" },
+                }}
               />
             </Grid>
           </Paper>
@@ -84,8 +87,11 @@ const CommissionTitleComponent: React.FC<CommissionTitleComponentProps> = (
                 onChange={(newValue) =>
                   newValue ? props.onExpirationChanged(newValue) : undefined
                 }
-                FormHelperTextProps={{style: {fontSize: "0.86rem"}}}
-                InputLabelProps={{ shrink: true, style: { fontSize: "1.2rem" } }}
+                FormHelperTextProps={{ style: { fontSize: "0.86rem" } }}
+                InputLabelProps={{
+                  shrink: true,
+                  style: { fontSize: "1.2rem" },
+                }}
               />
             </Grid>
           </Paper>
@@ -107,7 +113,10 @@ const CommissionTitleComponent: React.FC<CommissionTitleComponentProps> = (
                     style={{ width: 340 }}
                     {...params}
                     label="Working Group"
-                    InputLabelProps={{ shrink: true, style: { fontSize: "1.2rem" } }}
+                    InputLabelProps={{
+                      shrink: true,
+                      style: { fontSize: "1.2rem" },
+                    }}
                   />
                 )}
                 onChange={(event, newValue) => {

--- a/frontend/app/multistep/commissioncreate_new/CommissionTitleComponent.tsx
+++ b/frontend/app/multistep/commissioncreate_new/CommissionTitleComponent.tsx
@@ -48,7 +48,7 @@ const CommissionTitleComponent: React.FC<CommissionTitleComponentProps> = (
           <Paper className={classes.paperWithPadding}>
             <Grid item xs={6} sm={6}>
               <TextField
-                style={{ width: 300 }}
+                style={{ width: 340 }}
                 label="Commission Title"
                 placeholder="My commission title"
                 helperText="Enter a good descriptive Commission title"
@@ -64,6 +64,8 @@ const CommissionTitleComponent: React.FC<CommissionTitleComponentProps> = (
                   }
                 }}
                 value={props.title}
+                FormHelperTextProps={{style: {fontSize: "0.86rem"}}}
+                InputLabelProps={{ shrink: true, style: { fontSize: "1.2rem" } }}
               />
             </Grid>
           </Paper>
@@ -71,7 +73,7 @@ const CommissionTitleComponent: React.FC<CommissionTitleComponentProps> = (
             <Grid item xs={6} sm={6}>
               <KeyboardDatePicker
                 className={classes.inputBox}
-                style={{ width: 300 }}
+                style={{ width: 340 }}
                 disableToolbar
                 variant="inline"
                 format="dd/MM/yyyy"
@@ -82,6 +84,8 @@ const CommissionTitleComponent: React.FC<CommissionTitleComponentProps> = (
                 onChange={(newValue) =>
                   newValue ? props.onExpirationChanged(newValue) : undefined
                 }
+                FormHelperTextProps={{style: {fontSize: "0.86rem"}}}
+                InputLabelProps={{ shrink: true, style: { fontSize: "1.2rem" } }}
               />
             </Grid>
           </Paper>
@@ -100,9 +104,10 @@ const CommissionTitleComponent: React.FC<CommissionTitleComponentProps> = (
                 getOptionLabel={(option) => option.name}
                 renderInput={(params) => (
                   <TextField
-                    style={{ width: 300 }}
+                    style={{ width: 340 }}
                     {...params}
                     label="Working Group"
+                    InputLabelProps={{ shrink: true, style: { fontSize: "1.2rem" } }}
                   />
                 )}
                 onChange={(event, newValue) => {

--- a/frontend/app/multistep/projectcreate_new/ConfigurationComponent.tsx
+++ b/frontend/app/multistep/projectcreate_new/ConfigurationComponent.tsx
@@ -137,7 +137,7 @@ const ConfigurationComponent: React.FC<ConfigurationComponentProps> = (
           <Grid container spacing={4} alignItems="center">
             <Grid item xs={6} sm={6}>
               <TextField
-                style={{ width: 300 }}
+                style={{ width: 340 }}
                 label="Project Title"
                 placeholder="My project title"
                 helperText="Enter a good descriptive project name"
@@ -155,6 +155,8 @@ const ConfigurationComponent: React.FC<ConfigurationComponentProps> = (
                   }
                 }}
                 value={props.projectName}
+                FormHelperTextProps={{style: {fontSize: "0.86rem"}}}
+                InputLabelProps={{ shrink: true, style: { fontSize: "1.2rem" } }}
               />
             </Grid>
             {isAdmin && (

--- a/frontend/app/multistep/projectcreate_new/ConfigurationComponent.tsx
+++ b/frontend/app/multistep/projectcreate_new/ConfigurationComponent.tsx
@@ -155,8 +155,11 @@ const ConfigurationComponent: React.FC<ConfigurationComponentProps> = (
                   }
                 }}
                 value={props.projectName}
-                FormHelperTextProps={{style: {fontSize: "0.86rem"}}}
-                InputLabelProps={{ shrink: true, style: { fontSize: "1.2rem" } }}
+                FormHelperTextProps={{ style: { fontSize: "0.86rem" } }}
+                InputLabelProps={{
+                  shrink: true,
+                  style: { fontSize: "1.2rem" },
+                }}
               />
             </Grid>
             {isAdmin && (

--- a/frontend/app/multistep/projectcreate_new/ObituaryComponent.tsx
+++ b/frontend/app/multistep/projectcreate_new/ObituaryComponent.tsx
@@ -51,7 +51,7 @@ const ObituaryComponent = ({
         </>
       ) : (
         <Typography
-          style={{ fontSize: "0.75rem", color: theme.palette.text.secondary }}
+          style={{ fontSize: "0.86rem", color: theme.palette.text.secondary }}
         >
           Tick box to choose person for whom the obituary is intended
         </Typography>

--- a/frontend/app/multistep/projectcreate_new/ProductionOfficeComponent.tsx
+++ b/frontend/app/multistep/projectcreate_new/ProductionOfficeComponent.tsx
@@ -36,7 +36,7 @@ const ProductionOfficeComponent: React.FC<ProductionOfficeComponentProps> = (
           onChange={(evt) =>
             props.valueWasSet(evt.target.value as ProductionOffice)
           }
-          FormHelperTextProps={{style: {fontSize: "0.86rem"}}}
+          FormHelperTextProps={{ style: { fontSize: "0.86rem" } }}
           InputLabelProps={{ shrink: true, style: { fontSize: "1.2rem" } }}
         >
           {validProductionOffices.map((officeName, idx) => (

--- a/frontend/app/multistep/projectcreate_new/ProductionOfficeComponent.tsx
+++ b/frontend/app/multistep/projectcreate_new/ProductionOfficeComponent.tsx
@@ -29,13 +29,15 @@ const ProductionOfficeComponent: React.FC<ProductionOfficeComponentProps> = (
       <div>
         <TextField
           select
-          style={{ width: 300 }}
+          style={{ width: 340 }}
           label="Production Office"
           helperText="Production office you are working from"
           value={props.productionOfficeValue}
           onChange={(evt) =>
             props.valueWasSet(evt.target.value as ProductionOffice)
           }
+          FormHelperTextProps={{style: {fontSize: "0.86rem"}}}
+          InputLabelProps={{ shrink: true, style: { fontSize: "1.2rem" } }}
         >
           {validProductionOffices.map((officeName, idx) => (
             <MenuItem key={idx} value={officeName}>

--- a/frontend/app/multistep/projectcreate_new/TemplateComponent.tsx
+++ b/frontend/app/multistep/projectcreate_new/TemplateComponent.tsx
@@ -125,7 +125,7 @@ const TemplateComponent: React.FC<TemplateComponentProps> = (props) => {
                 (evt.target.value as unknown) as number
               )
             }
-            FormHelperTextProps={{style: {fontSize: "0.86rem"}}}
+            FormHelperTextProps={{ style: { fontSize: "0.86rem" } }}
             InputLabelProps={{ shrink: true, style: { fontSize: "1.2rem" } }}
           >
             {knownProjectTemplates.map((template, idx) => (

--- a/frontend/app/multistep/projectcreate_new/TemplateComponent.tsx
+++ b/frontend/app/multistep/projectcreate_new/TemplateComponent.tsx
@@ -116,7 +116,7 @@ const TemplateComponent: React.FC<TemplateComponentProps> = (props) => {
         {props.templateValue ? (
           <TextField
             select
-            style={{ width: 300 }}
+            style={{ width: 340 }}
             label="Project template"
             helperText="Please select a project template"
             value={props.templateValue}
@@ -125,6 +125,8 @@ const TemplateComponent: React.FC<TemplateComponentProps> = (props) => {
                 (evt.target.value as unknown) as number
               )
             }
+            FormHelperTextProps={{style: {fontSize: "0.86rem"}}}
+            InputLabelProps={{ shrink: true, style: { fontSize: "1.2rem" } }}
           >
             {knownProjectTemplates.map((template, idx) => (
               <MenuItem value={template.id} key={idx}>


### PR DESCRIPTION
## What does this change?

Makes some text larger.

## How can we measure success?

Some text is larger.

## Images

![PC120](https://github.com/user-attachments/assets/6e63bf0d-8b79-4b61-b087-2a03266d7d6a)

![PC121](https://github.com/user-attachments/assets/ac885f12-9317-4f0a-8303-4868eea11a4e)

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.