### PR TITLE
Removes Possibly Broken Code

### DIFF
--- a/frontend/app/CommissionsList/CommissionsList.tsx
+++ b/frontend/app/CommissionsList/CommissionsList.tsx
@@ -247,38 +247,30 @@ const CommissionsList: React.FC = () => {
                   status,
                   owner,
                   confidential,
-                }) => {
-                  if (userAllowed(confidential, owner)) {
-                    return (
-                      <TableRow
-                        hover={true}
-                        onClick={() => {
-                          window.open(
-                            `${deploymentRootPath}commission/${id}`,
-                            "_blank"
-                          );
-                        }}
-                        key={id}
-                        onContextMenu={(e) => {
-                          handleContextMenu(e, id);
-                        }}
-                      >
-                        <TableCell>{title}</TableCell>
-                        <TableCell>{projectCount}</TableCell>
-                        <TableCell>
-                          {new Date(created).toLocaleString()}
-                        </TableCell>
-                        <TableCell>
-                          {workingGroups.get(workingGroupId) ?? "<Unknown>"}
-                        </TableCell>
-                        <TableCell>{status}</TableCell>
-                        <TableCell>{owner.replace(/\|/g, " ")}</TableCell>
-                      </TableRow>
-                    );
-                  } else {
-                    return null;
-                  }
-                }
+                }) => (
+                  <TableRow
+                    hover={true}
+                    onClick={() => {
+                      window.open(
+                        `${deploymentRootPath}commission/${id}`,
+                        "_blank"
+                      );
+                    }}
+                    key={id}
+                    onContextMenu={(e) => {
+                      handleContextMenu(e, id);
+                    }}
+                  >
+                    <TableCell>{title}</TableCell>
+                    <TableCell>{projectCount}</TableCell>
+                    <TableCell>{new Date(created).toLocaleString()}</TableCell>
+                    <TableCell>
+                      {workingGroups.get(workingGroupId) ?? "<Unknown>"}
+                    </TableCell>
+                    <TableCell>{status}</TableCell>
+                    <TableCell>{owner.replace(/\|/g, " ")}</TableCell>
+                  </TableRow>
+                )
               )}
             </TableBody>
           </Table>


### PR DESCRIPTION
## What does this change?

Removes some code which may be causing commisson lists not to display correctly for some users.

## How can we measure success?

No users have issues with the commission lists.

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2.