### PR TITLE
Make userAllowed Method More Robust

### DIFF
--- a/frontend/app/ProjectEntryList/ProjectsTable.tsx
+++ b/frontend/app/ProjectEntryList/ProjectsTable.tsx
@@ -234,6 +234,9 @@ const ProjectsTable: React.FC<ProjectsTableProps> = (props) => {
   };
 
   const userAllowed = (confidential: Boolean, projectUser: string) => {
+    if (confidential == undefined) {
+      return true;
+    }
     if (confidential == false) {
       return true;
     }
@@ -245,6 +248,8 @@ const ProjectsTable: React.FC<ProjectsTableProps> = (props) => {
       } else {
         return false;
       }
+    } else {
+      return true;
     }
   };
 


### PR DESCRIPTION
## What does this change?

Makes the userAllowed method able to cope if confidential is undefined and if user is null.

## How can we measure success?

Less errors displaying the project lists should be seen.

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2.