### PR TITLE
Check User Name as Lower Case

### DIFF
--- a/frontend/app/CommissionsList/CommissionEntryEditComponent.tsx
+++ b/frontend/app/CommissionsList/CommissionEntryEditComponent.tsx
@@ -475,7 +475,9 @@ const CommissionEntryEditComponent: React.FC<RouteComponentProps<
         const loggedIn = await isLoggedIn();
         if (loggedIn.isAdmin) {
           setUserAllowedBoolean(true);
-        } else if (commissionData?.owner.split("|").includes(loggedIn.uid)) {
+        } else if (
+          commissionData?.owner.split("|").includes(loggedIn.uid.toLowerCase())
+        ) {
           setUserAllowedBoolean(true);
         } else {
           setUserAllowedBoolean(false);

--- a/frontend/app/CommissionsList/CommissionsList.tsx
+++ b/frontend/app/CommissionsList/CommissionsList.tsx
@@ -161,7 +161,7 @@ const CommissionsList: React.FC = () => {
     if (user != null) {
       if (user.isAdmin) {
         return true;
-      } else if (commissionUser.split("|").includes(user.uid)) {
+      } else if (commissionUser.split("|").includes(user.uid.toLowerCase())) {
         return true;
       } else {
         return false;

--- a/frontend/app/ProjectEntryList/ProjectEntryEditComponent.tsx
+++ b/frontend/app/ProjectEntryList/ProjectEntryEditComponent.tsx
@@ -318,7 +318,9 @@ const ProjectEntryEditComponent: React.FC<ProjectEntryEditComponentProps> = (
         const loggedIn = await isLoggedIn();
         if (loggedIn.isAdmin) {
           setUserAllowedBoolean(true);
-        } else if (project.user.split("|").includes(loggedIn.uid)) {
+        } else if (
+          project.user.split("|").includes(loggedIn.uid.toLowerCase())
+        ) {
           setUserAllowedBoolean(true);
         } else {
           setUserAllowedBoolean(false);

--- a/frontend/app/ProjectEntryList/ProjectsTable.tsx
+++ b/frontend/app/ProjectEntryList/ProjectsTable.tsx
@@ -243,7 +243,9 @@ const ProjectsTable: React.FC<ProjectsTableProps> = (props) => {
     if (props.user != null) {
       if (props.user.isAdmin) {
         return true;
-      } else if (projectUser.split("|").includes(props.user.uid)) {
+      } else if (
+        projectUser.split("|").includes(props.user.uid.toLowerCase())
+      ) {
         return true;
       } else {
         return false;


### PR DESCRIPTION
## What does this change?

Checks the user name as lower case.

## How can we measure success?

Upper case user names should no longer cause permission issues.

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.