### PR TITLE
Add Place Holder Text on New Commission Page

### DIFF
--- a/frontend/app/multistep/commissioncreate_new/CommissionTitleComponent.tsx
+++ b/frontend/app/multistep/commissioncreate_new/CommissionTitleComponent.tsx
@@ -113,6 +113,7 @@ const CommissionTitleComponent: React.FC<CommissionTitleComponentProps> = (
                     style={{ width: 340 }}
                     {...params}
                     label="Working Group"
+                    placeholder="Start typing category name"
                     InputLabelProps={{
                       shrink: true,
                       style: { fontSize: "1.2rem" },


### PR DESCRIPTION
## What does this change?

Adds some text.

## How can we measure success?

The text displays.

## Images

![PC123](https://github.com/user-attachments/assets/d82612f9-c434-425e-8aee-15fd8ad700e2)

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2.