### PR TITLE
Removing Styling

### DIFF
--- a/frontend/app/multistep/commissioncreate_new/CommissionTitleComponent.tsx
+++ b/frontend/app/multistep/commissioncreate_new/CommissionTitleComponent.tsx
@@ -126,9 +126,7 @@ const CommissionTitleComponent: React.FC<CommissionTitleComponentProps> = (
                   }
                 }}
                 PaperComponent={({ children, ...other }) => (
-                  <Paper {...other} style={{ maxHeight: 370 }}>
-                    {children}
-                  </Paper>
+                  <Paper {...other}>{children}</Paper>
                 )}
               />
             </Grid>


### PR DESCRIPTION
## What does this change?

Removes some styling from a menu.

## How can we measure success?

The menu displays data in a way that allows access to all the items.

## Images

![Screenshot 2024-10-03 at 13 12 54](https://github.com/user-attachments/assets/2380c13b-e445-4df4-8b64-89e8cb421a36)

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.