### PR TITLE
Fix project update logic

### DIFF
--- a/app/models/ProjectEntry.scala
+++ b/app/models/ProjectEntry.scala
@@ -284,8 +284,8 @@ object ProjectEntry extends ((Option[Int], Int, Option[String], String, Timestam
         )
         getProjects(filteredQuery)
 
-      case EntryStatus.InProgress =>
-        // No changes needed for In Progress
+      case EntryStatus.InProduction =>
+        // No changes needed for In Production
         DBIO.successful(Seq.empty[(Int, ProjectEntry)])
 
       case _ => 

--- a/app/models/ProjectEntry.scala
+++ b/app/models/ProjectEntry.scala
@@ -259,20 +259,37 @@ object ProjectEntry extends ((Option[Int], Int, Option[String], String, Timestam
     val baseQuery = TableQuery[ProjectEntryRow].filter(_.commission === commissionId)
 
     newStatus match {
-      case EntryStatus.Completed | EntryStatus.Killed =>
-        val filteredQuery = baseQuery
-          .filter(_.status =!= EntryStatus.Completed)
-          .filter(_.status =!= EntryStatus.Killed)
+      case EntryStatus.Completed =>
+        // All projects NOT Completed or Killed should be set to Completed
+        val filteredQuery = baseQuery.filter(p => 
+          p.status =!= EntryStatus.Completed && 
+          p.status =!= EntryStatus.Killed
+        )
+        getProjects(filteredQuery)
+
+      case EntryStatus.Killed =>
+        // All projects NOT Completed or Killed should be set to Killed
+        val filteredQuery = baseQuery.filter(p => 
+          p.status =!= EntryStatus.Completed && 
+          p.status =!= EntryStatus.Killed
+        )
         getProjects(filteredQuery)
 
       case EntryStatus.Held =>
-        val filteredQuery = baseQuery
-          .filter(_.status =!= EntryStatus.Completed)
-          .filter(_.status =!= EntryStatus.Killed)
-          .filter(_.status =!= EntryStatus.Held)
+        // All projects NOT Completed, Killed or Held should be set to Held
+        val filteredQuery = baseQuery.filter(p => 
+          p.status =!= EntryStatus.Completed && 
+          p.status =!= EntryStatus.Killed &&
+          p.status =!= EntryStatus.Held
+        )
         getProjects(filteredQuery)
 
-      case _ => DBIO.successful(Seq.empty[(Int, ProjectEntry)])
+      case EntryStatus.InProgress =>
+        // No changes needed for In Progress
+        DBIO.successful(Seq.empty[(Int, ProjectEntry)])
+
+      case _ => 
+        DBIO.successful(Seq.empty[(Int, ProjectEntry)])
     }
   }
 

--- a/app/services/CommissionStatusPropagator.scala
+++ b/app/services/CommissionStatusPropagator.scala
@@ -5,7 +5,7 @@ import akka.actor.{Actor, ActorRef, Props}
 import com.fasterxml.jackson.core.`type`.TypeReference
 import com.fasterxml.jackson.module.scala.JsonScalaEnumeration
 import com.google.inject.Inject
-import models.{EntryStatus, PlutoCommission, PlutoCommissionRow, ProjectEntry, ProjectEntryRow, ProjectEntrySerializer}
+import models.{EntryStatus, ProjectEntry, ProjectEntryRow, ProjectEntrySerializer}
 import org.slf4j.LoggerFactory
 import play.api.Logger
 import play.api.db.slick.DatabaseConfigProvider
@@ -17,9 +17,7 @@ import slick.jdbc.PostgresProfile.api._
 import javax.inject.Named
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
-
 object CommissionStatusPropagator {
   private val logger = LoggerFactory.getLogger(getClass)
   def props = Props[CommissionStatusPropagator]
@@ -110,62 +108,26 @@ class CommissionStatusPropagator @Inject() (dbConfigProvider: DatabaseConfigProv
   }
 
     def updateCommissionProjects(newStatus: EntryStatus.Value, commissionId: Int): Future[Seq[Try[Int]]] = {
-      logger.info(s"Starting project updates for commission $commissionId to status $newStatus")
-      
-      // First, get current commission status to verify
-      val action = for {
-        commission <- TableQuery[PlutoCommissionRow]
-          .filter(_.id === commissionId)
-          .result
-          .headOption
-        _ = if (commission.isEmpty) throw new RuntimeException(s"Commission $commissionId not found")
-        _ = if (commission.get.status != newStatus) throw new RuntimeException(s"Commission $commissionId status mismatch: expected $newStatus but found ${commission.get.status}")
-        
-        projectsWithIds <- ProjectEntry.getProjectsEligibleForStatusChange(newStatus, commissionId)
-        _ = logger.info(s"Commission $commissionId status change to $newStatus: Found ${projectsWithIds.length} eligible projects: ${projectsWithIds.map { case (id, proj) => s"$id (current: ${proj.status})" }.mkString(", ")}")
-        
-        updates <- DBIO.sequence(projectsWithIds.map { case (projectId, project) =>
-          val updatedProject = project.copy(status = newStatus)
-          TableQuery[ProjectEntryRow]
-            .filter(_.id === projectId)
-            .update(updatedProject)
-            .map(result => (result, updatedProject))
-        }).transactionally
-      } yield (projectsWithIds, updates)
+      val action: DBIO[Seq[(Int, ProjectEntry)]] = ProjectEntry.getProjectsEligibleForStatusChange(newStatus, commissionId)
 
-      dbConfig.db.run(action).flatMap { case (projectsWithIds, results) =>
-        val successfulUpdates = results.collect { 
-          case (updateResult, _) if updateResult > 0 => updateResult 
-        }
-        
-        logger.info(s"Commission $commissionId status change to $newStatus: Successfully updated ${successfulUpdates.length}/${projectsWithIds.length} projects")
-        
-        val updateResults = projectsWithIds.zip(results).map { 
-          case ((projectId, _), (updateResult, updatedProject)) =>
-            if (updateResult > 0) {
+      dbConfig.db.run(action).flatMap { projectTuples =>
+
+        // Map over each tuple, update the project's status and then update it in the database
+        val updateActions = projectTuples.map { case (id, project) =>
+          val updatedProject = project.copy(status = newStatus)
+          val dbUpdateAction = dbConfig.db.run(TableQuery[ProjectEntryRow].filter(_.id === id).update(updatedProject))
+          // Convert the DB update future to a Try and then send the updated project to RabbitMQ
+          dbUpdateAction.transformWith {
+            case Success(_) =>
               val projectSerializer = new ProjectEntrySerializer {}
               implicit val projectsWrites: Writes[ProjectEntry] = projectSerializer.projectEntryWrites
               rabbitMqPropagator ! ChangeEvent(Seq(projectsWrites.writes(updatedProject)), Some("project"), UpdateOperation())
-              Success(projectId)
-            } else {
-              logger.error(s"Commission $commissionId: Failed to update project $projectId to status $newStatus")
-              Failure(new RuntimeException(s"Failed to update project $projectId"))
-            }
-        }
-        
-        // If not all projects were updated, retry the entire operation
-        if (successfulUpdates.length < projectsWithIds.length) {
-          logger.warn(s"Commission $commissionId: Not all projects were updated (${successfulUpdates.length}/${projectsWithIds.length}). Scheduling retry...")
-          context.system.scheduler.scheduleOnce(5.seconds) {
-            self ! CommissionStatusUpdate(commissionId, newStatus)
+              Future.successful(Success(id))
+            case Failure(err) => Future.successful(Failure(err))
           }
         }
-        
-        Future.successful(updateResults)
-      }.recover {
-        case err =>
-          logger.error(s"Failed to update projects for commission $commissionId to status $newStatus", err)
-          Seq(Failure(err))
+        // Execute all update actions concurrently using Future.sequence
+        Future.sequence(updateActions)
       }
     }
   }

--- a/app/services/CommissionStatusPropagator.scala
+++ b/app/services/CommissionStatusPropagator.scala
@@ -5,7 +5,7 @@ import akka.actor.{Actor, ActorRef, Props}
 import com.fasterxml.jackson.core.`type`.TypeReference
 import com.fasterxml.jackson.module.scala.JsonScalaEnumeration
 import com.google.inject.Inject
-import models.{EntryStatus, ProjectEntry, ProjectEntryRow, ProjectEntrySerializer}
+import models.{EntryStatus, PlutoCommission, PlutoCommissionRow, ProjectEntry, ProjectEntryRow, ProjectEntrySerializer}
 import org.slf4j.LoggerFactory
 import play.api.Logger
 import play.api.db.slick.DatabaseConfigProvider
@@ -17,7 +17,9 @@ import slick.jdbc.PostgresProfile.api._
 import javax.inject.Named
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
+
 object CommissionStatusPropagator {
   private val logger = LoggerFactory.getLogger(getClass)
   def props = Props[CommissionStatusPropagator]

--- a/app/services/CommissionStatusPropagator.scala
+++ b/app/services/CommissionStatusPropagator.scala
@@ -117,41 +117,44 @@ class CommissionStatusPropagator @Inject() (dbConfigProvider: DatabaseConfigProv
           val updateActions = projectTuples.map { case (id, project) =>
             val updatedProject = project.copy(status = newStatus)
             
-            // Create a transaction with explicit commit logging
+            // Combine update and verification in a single transaction
             val updateAction = (for {
               _ <- DBIO.successful(logger.info(s"Starting transaction for project $id"))
-              updateCount <- TableQuery[ProjectEntryRow].filter(_.id === id).update(updatedProject).transactionally
+              updateCount <- TableQuery[ProjectEntryRow].filter(_.id === id).update(updatedProject)
               _ = logger.info(s"Database update for project $id completed with count: $updateCount")
-              // Verify the update by reading back the data
+              // Verify the update within the same transaction
               verification <- TableQuery[ProjectEntryRow].filter(_.id === id).result.headOption
               _ = verification match {
                 case Some(updated) if updated.status == newStatus => 
                   logger.info(s"Verified project $id is now status: ${updated.status}")
                 case Some(updated) => 
                   logger.warn(s"Project $id status mismatch - expected: $newStatus, actual: ${updated.status}")
+                  throw new Exception(s"Project $id status mismatch - expected: $newStatus, actual: ${updated.status}")
                 case None =>
                   logger.error(s"Could not verify project $id - not found after update")
+                  throw new Exception(s"Project $id not found after update")
               }
-            } yield updateCount).asTry
+            } yield (updateCount, verification)).transactionally.asTry
             
-            dbConfig.db.run(updateAction).map { result =>
-              result match {
-                case Success(count) if count > 0 =>
-                  val projectSerializer = new ProjectEntrySerializer {}
-                  implicit val projectsWrites: Writes[ProjectEntry] = projectSerializer.projectEntryWrites
-                  rabbitMqPropagator.tell(
-                    ChangeEvent(Seq(projectsWrites.writes(updatedProject)), Some("project"), UpdateOperation()),
-                    Actor.noSender
-                  )
-                  logger.info(s"Successfully updated project $id and sent to RabbitMQ")
-                  Success(id)
-                case Success(0) =>
-                  logger.error(s"Project $id update affected 0 rows - possible concurrency issue or project already updated")
-                  Failure(new Exception(s"Project $id update failed - no rows affected"))
-                case Failure(err) =>
-                  logger.error(s"Failed to update project $id", err)
-                  Failure(err)
-              }
+            dbConfig.db.run(updateAction).map {
+              case Success((count, Some(updated))) if updated.status == newStatus =>
+                val projectSerializer = new ProjectEntrySerializer {}
+                implicit val projectsWrites: Writes[ProjectEntry] = projectSerializer.projectEntryWrites
+                rabbitMqPropagator.tell(
+                  ChangeEvent(Seq(projectsWrites.writes(updatedProject)), Some("project"), UpdateOperation()),
+                  Actor.noSender
+                )
+                logger.info(s"Successfully updated project $id and sent to RabbitMQ")
+                Success(id)
+              case Success((_, Some(updated))) =>
+                logger.error(s"Project $id update verification failed - status mismatch")
+                Failure(new Exception(s"Project $id update verification failed"))
+              case Success((_, None)) =>
+                logger.error(s"Project $id update verification failed - project not found")
+                Failure(new Exception(s"Project $id not found after update"))
+              case Failure(err) =>
+                logger.error(s"Failed to update project $id", err)
+                Failure(err)
             }
           }
           
@@ -160,9 +163,6 @@ class CommissionStatusPropagator @Inject() (dbConfigProvider: DatabaseConfigProv
             logger.info(s"Update complete: ${successes.length} successes, ${failures.length} failures")
             if (failures.nonEmpty) {
               logger.error(s"Failed project updates: ${failures.map(_.failed.get.getMessage).mkString(", ")}")
-            }
-            if (projectsToVerify.nonEmpty) {
-              logger.info(s"Final status check for specific projects: ${projectsToVerify.mkString(", ")}")
             }
             results
           }


### PR DESCRIPTION
These changes should result in more consistent and reliable updates, ensuring that all eligible projects are correctly updated to "Completed" when their parent commission is set to "Completed."

- Added transaction verification to ensure project status updates are committed correctly
- Improved logging to track update progress and failures
- Clarified project status change logic in `getProjectsEligibleForStatusChange`
- Fixed issue where projects were incorrectly reporting success despite status mismatch
- Removed duplicate RabbitMQ messages

The changes ensure that when a commission status changes, all eligible projects are properly updated and verified within a single transaction.

Tested on the dev system.