### PR TITLE
Only Validate Owners when Enter Pressed

### DIFF
--- a/frontend/app/common/UsersAutoComplete.tsx
+++ b/frontend/app/common/UsersAutoComplete.tsx
@@ -61,10 +61,15 @@ const UsersAutoComplete: React.FC<UsersAutoCompleteProps> = (props) => {
   };
 
   const inputDidChange = (evt: ChangeEvent<{}>, newValue: string | null) => {
-    if (props.shouldValidate) {
-      if (newValue) validateEntry(newValue);
-    }
     setInputValue(newValue ?? "");
+  };
+
+  const keyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key == "Enter") {
+      if (props.shouldValidate) {
+        validateEntry(inputValue);
+      }
+    }
   };
 
   return (
@@ -78,6 +83,7 @@ const UsersAutoComplete: React.FC<UsersAutoCompleteProps> = (props) => {
       onChange={props.valueDidChange}
       //onInputChange is fired when the user types
       onInputChange={inputDidChange}
+      onKeyDown={keyPress}
       options={userOptions}
       renderInput={(params) => (
         <TextField


### PR DESCRIPTION
## What does this change?

Stops an error message displaying when the user selects an owner from the menu after typing part of the name.

## How can we measure success?

The error message does not display when the user selects an owner from the menu after typing part of the name.

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.