### PR TITLE
Warn if the Project is to be Set to Completed and is Less Than Twenty Four Hours Old

### DIFF
--- a/frontend/app/ProjectEntryList/ProjectEntryEditComponent.tsx
+++ b/frontend/app/ProjectEntryList/ProjectEntryEditComponent.tsx
@@ -384,23 +384,13 @@ const ProjectEntryEditComponent: React.FC<ProjectEntryEditComponentProps> = (
     }
   };
 
-  const checkProjectDate = () => {
-    const createdUNIX = Math.floor(new Date(project.created).getTime() / 1000);
-    const currentUNIX = Date.now() / 1000;
-    if (currentUNIX - createdUNIX < 86400) {
-      return false;
-    } else {
-      return true;
-    }
+  const isProjectOlderThanOneDay = () => {
+    const createdUNIX = new Date(project.created).getTime();
+    const currentUNIX = Date.now();
+    return currentUNIX - createdUNIX >= 86400000;
   };
 
-  const newStatusIsCompleted = () => {
-    if (project.status == "Completed") {
-      return true;
-    } else {
-      return false;
-    }
-  };
+  const newStatusIsCompleted = () => project.status === "Completed";
 
   const abortChanges = () => {
     if (initialProject) {
@@ -681,7 +671,7 @@ const ProjectEntryEditComponent: React.FC<ProjectEntryEditComponentProps> = (
                     />
                   </Tooltip>
                   {hasChanges() ? ( // Only render if changes have been made
-                    checkProjectDate() ? (
+                    isProjectOlderThanOneDay() ? (
                       <div
                         style={{ height: "48px" }}
                         className={classes.formButtons}

--- a/frontend/app/ProjectEntryList/ProjectEntryEditComponent.tsx
+++ b/frontend/app/ProjectEntryList/ProjectEntryEditComponent.tsx
@@ -384,6 +384,30 @@ const ProjectEntryEditComponent: React.FC<ProjectEntryEditComponentProps> = (
     }
   };
 
+  const checkProjectDate = () => {
+    const createdUNIX = Math.floor(new Date(project.created).getTime() / 1000);
+    const currentUNIX = Date.now() / 1000;
+    if (currentUNIX - createdUNIX < 86400) {
+      return false;
+    } else {
+      return true;
+    }
+  };
+
+  const newStatusIsCompleted = () => {
+    if (project.status == "Completed") {
+      return true;
+    } else {
+      return false;
+    }
+  };
+
+  const abortChanges = () => {
+    if (initialProject) {
+      setProject(initialProject);
+    }
+  };
+
   return (
     <>
       {userAllowedBoolean ? (
@@ -656,20 +680,65 @@ const ProjectEntryEditComponent: React.FC<ProjectEntryEditComponentProps> = (
                       label="Private"
                     />
                   </Tooltip>
-                  <div
-                    style={{ height: "48px" }}
-                    className={classes.formButtons}
-                  >
-                    {hasChanges() && ( // Only render if changes have been made
-                      <Button
-                        type="submit"
-                        color="secondary"
-                        variant="contained"
+                  {hasChanges() ? ( // Only render if changes have been made
+                    checkProjectDate() ? (
+                      <div
+                        style={{ height: "48px" }}
+                        className={classes.formButtons}
                       >
-                        Save changes
-                      </Button>
-                    )}
-                  </div>
+                        <Button
+                          type="submit"
+                          color="secondary"
+                          variant="contained"
+                        >
+                          Save changes
+                        </Button>
+                      </div>
+                    ) : newStatusIsCompleted() ? (
+                      <div>
+                        <Typography style={{ marginTop: "30px" }}>
+                          Are you sure you want to set this project to Completed
+                          so soon? If you have just copied a large number of
+                          files to the project asset folder then please wait
+                          another day before setting this to Completed, to
+                          ensure all the files for this project have been
+                          properly backed up.
+                        </Typography>
+                        <div
+                          style={{ height: "48px" }}
+                          className={classes.formButtons}
+                        >
+                          <Button
+                            color="secondary"
+                            variant="contained"
+                            onClick={() => abortChanges()}
+                          >
+                            Come back later
+                          </Button>
+                          <Button
+                            type="submit"
+                            color="secondary"
+                            variant="contained"
+                          >
+                            Save changes
+                          </Button>
+                        </div>
+                      </div>
+                    ) : (
+                      <div
+                        style={{ height: "48px" }}
+                        className={classes.formButtons}
+                      >
+                        <Button
+                          type="submit"
+                          color="secondary"
+                          variant="contained"
+                        >
+                          Save changes
+                        </Button>
+                      </div>
+                    )
+                  ) : null}
                 </Grid>
               </Grid>
             </form>


### PR DESCRIPTION
## What does this change?

Adds a warning and abort button if the project is to be set to Completed and is less than twenty four hours old.

## How can we measure success?

The warning and button display when the project is to be set to completed and the project is less than twenty four hours old.

## Images

![Screenshot 2025-01-15 at 12 22 57](https://github.com/user-attachments/assets/40af4769-3279-4a85-bc53-cc03c71a8895)

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.