### PR TITLE
Time Out and Refresh Keys

### DIFF
--- a/app/auth/BearerTokenAuth.scala
+++ b/app/auth/BearerTokenAuth.scala
@@ -47,8 +47,8 @@ class BearerTokenAuth @Inject() (config:Configuration) {
   //see https://stackoverflow.com/questions/475074/regex-to-parse-or-validate-base64-data
   //it is not the best option but is the simplest that will work here
   private val authXtractor = "^Bearer\\s+([a-zA-Z0-9+/._-]*={0,3})$".r
-
-  private val maybeVerifiers = loadInKey() match {
+  var loadTime: Long = System.currentTimeMillis / 1000
+  private var maybeVerifiers = loadInKey() match {
     case Failure(err)=>
       if(!sys.env.contains("CI")) logger.warn(s"No token validation cert in config so bearer token auth will not work. Error was ${err.getMessage}")
       None
@@ -99,6 +99,7 @@ class BearerTokenAuth @Inject() (config:Configuration) {
    * @return Either an initialised JWKSet or a Failure indicating why it would not load.
    */
   def loadInKey():Try[JWKSet] = Try {
+    loadTime = System.currentTimeMillis / 1000
     val isRemoteMatcher = "^https*:".r.unanchored
 
     if(isRemoteMatcher.matches(signingCertPath)) {
@@ -145,6 +146,16 @@ class BearerTokenAuth @Inject() (config:Configuration) {
       SignedJWT.parse(token.content)
     } match {
       case Success(signedJWT) =>
+        if ((System.currentTimeMillis / 1000) - loadTime > config.get[Int]("auth.keyTimeOut")) {
+          logger.debug(s"Keys too old. Attempting key refresh.")
+          maybeVerifiers = loadInKey() match {
+            case Failure(err)=>
+              if(!sys.env.contains("CI")) logger.warn(s"Could not load keys. Error was ${err.getMessage}")
+              None
+            case Success(jwk)=>
+              Some(jwk)
+          }
+        }
         getVerifier(Option(signedJWT.getHeader.getKeyID)) match {
           case Some(verifier)=>
             if (signedJWT.verify(verifier)) {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -265,6 +265,7 @@ deployment-root = ""
 auth {
   tokenSigningCertPath = "public/meta/oauth/publickey.pem"
   adminClaim = "multimedia_admin"
+  keyTimeOut = 86400
 }
 
 datamigration {


### PR DESCRIPTION
## What does this change?

Times out keys after a certain amount of seconds and attempts to download new keys before they are used.

Requires new setting of auth.keyTimeOut in a number of seconds be present in the application configuration file.

## How can we measure success?

Keys should be invalid less often.

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.