### PR TITLE
Allow Users to Attempt to Update Large Project Files

### DIFF
--- a/app/controllers/Files.scala
+++ b/app/controllers/Files.scala
@@ -261,8 +261,8 @@ class Files @Inject() (backupService:NewProjectBackup, temporaryFileCreator: pla
           logger.warn(s"Creating an incremental backup for ${fileEntry.filepath} on storage ${actualBackupStorage.storageType} ${actualBackupStorage.id}")
           for {
             maybeProjectEntry <- ProjectEntry.projectForFileEntry(fileEntry)
-            mostRecentBackup <- if (maybeProjectEntry.isDefined) maybeProjectEntry.get.mostRecentBackup else Future(None)
-            _ <- Future(logger.warn(s"In backupStorage inner for: maybeProjectEntry: ${maybeProjectEntry} mostRecentBackup: ${mostRecentBackup} maybeProjectEntry mostRecentBackup: ${maybeProjectEntry.get.mostRecentBackup}"))
+            mostRecentBackup <- if (maybeProjectEntry.isDefined) maybeProjectEntry.get.mostRecentBackup(db, mat, Some(fileEntry.storageId)) else Future(None)
+            _ <- Future(logger.warn(s"In backupStorage inner for: maybeProjectEntry: ${maybeProjectEntry} mostRecentBackup: ${mostRecentBackup} maybeProjectEntry mostRecentBackup: ${maybeProjectEntry.get.mostRecentBackup(db, mat, actualBackupStorage.id)}"))
             result <- backupService.performBackup(fileEntry, mostRecentBackup, actualBackupStorage).map(Some.apply)
           } yield result
         case None =>

--- a/app/models/ProjectEntry.scala
+++ b/app/models/ProjectEntry.scala
@@ -63,8 +63,8 @@ extends PlutoModel{
     } yield result
   }
 
-  def mostRecentBackup(implicit db:slick.jdbc.PostgresProfile#Backend#Database, mat:Materializer) = {
-    Source.fromPublisher(db.stream(projectFilesLookupQuery(None).result))
+  def mostRecentBackup(implicit db:slick.jdbc.PostgresProfile#Backend#Database, mat:Materializer, maybeStorageId:Option[Int]) = {
+    Source.fromPublisher(db.stream(projectFilesLookupQuery(Some(maybeStorageId.get)).result))
       .toMat(Sink.headOption)(Keep.right)
       .run()
       .map(_.map(_._2))

--- a/app/services/PremiereVersionConverter.scala
+++ b/app/services/PremiereVersionConverter.scala
@@ -59,7 +59,7 @@ class PremiereVersionConverter @Inject() (backupService:NewProjectBackup)(implic
           logger.info(s"Creating an incremental backup for ${fileEntry.filepath} on storage ${actualBackupStorage.storageType} ${actualBackupStorage.id}")
           for {
             maybeProjectEntry <- ProjectEntry.projectForFileEntry(fileEntry)
-            mostRecentBackup <- if (maybeProjectEntry.isDefined) maybeProjectEntry.get.mostRecentBackup else Future(None)
+            mostRecentBackup <- if (maybeProjectEntry.isDefined) maybeProjectEntry.get.mostRecentBackup(db, mat, actualBackupStorage.id) else Future(None)
             result <- backupService.performBackup(fileEntry, mostRecentBackup, actualBackupStorage).map(Some.apply)
           } yield result
         case None=>

--- a/frontend/app/PremiereVersionChange/PremiereVersionChange.tsx
+++ b/frontend/app/PremiereVersionChange/PremiereVersionChange.tsx
@@ -40,7 +40,7 @@ const PremiereVersionChange: React.FC<RouteComponentProps> = (props) => {
   const [targetVersionName, setTargetVersionName] = useState("");
   const [fileId, setFileId] = useState<number | undefined>(undefined);
   const [fileSize, setFileSize] = useState<number | undefined>(undefined);
-
+  const [failedLarge, setFailedLarge] = useState(false);
   const [conversionInProgress, setConversionInProgress] = useState(false);
   const [newOpenUrl, setNewOpenUrl] = useState<string | undefined>(undefined);
   const [popupBlocked, setPopupBlocked] = useState(false);
@@ -111,17 +111,6 @@ const PremiereVersionChange: React.FC<RouteComponentProps> = (props) => {
     }
   }, [fileId]);
 
-  useEffect(() => {
-    if (fileSize && fileSize > largestSupportedFile) {
-      console.warn(
-        `File size is ${fileSize} which is larger than the preconfigured limit of ${largestSupportedFile}`
-      );
-      setLastError(
-        "This project is too large to be reliably converted automatically. Please contact multimediatech@theguardian.com who can perform the conversion manually."
-      );
-    }
-  }, [fileSize]);
-
   /**
    * User does not want to continue. If the window was opened directly then close it, otherwise go back to the root page.
    */
@@ -162,6 +151,9 @@ const PremiereVersionChange: React.FC<RouteComponentProps> = (props) => {
           setConversionInProgress(false);
         } else {
           console.error(err);
+          if (fileSize && fileSize > largestSupportedFile) {
+            setFailedLarge(true);
+          }
           if (typeof err == "string") {
             setLastError(err);
           } else {
@@ -202,6 +194,20 @@ const PremiereVersionChange: React.FC<RouteComponentProps> = (props) => {
           Change Premiere project's version
         </Typography>
         {loading || conversionInProgress ? <LinearProgress /> : undefined}
+        {failedLarge ? (
+          <Typography className={classes.centered}>
+            This project is too large to be automatically updated to a newer
+            version of Adobe Premiere by Pluto. Please contact
+            multimediatech@theguardian.com for assistance.
+            <br />
+            <br />
+            If you need to open this urgently then make sure you choose the
+            "Open Anyway" button. As the project opens, Premiere Pro will
+            request you to rename the project file. Make sure you remove the
+            "_1" bit that is added to the end of the filename and click save.
+            Then let it overwrite when prompted.
+          </Typography>
+        ) : undefined}
         {lastError ? (
           <Typography className={classes.centered}>
             <Error


### PR DESCRIPTION
## What does this change?

Allows users to attempt to update large project files. When an update fails, instructions are displayed.

Also fixes an issue with the mostRecentBackup function. This can now have the storage to check on fed into it so it can output correct data.

## How can we measure success?

Users can now attempt to update large project files.

## Images

![PC125](https://github.com/user-attachments/assets/72a775a1-2711-4624-9e00-c7def2a912f5)

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.