### PR TITLE
Optional Pause in Backup Loop

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,7 +149,7 @@ jobs:
         run: cat build-info.yaml
 
       - name: Upload build info
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-info
           path: build-info.yaml

--- a/app/services/ProjectBackupAssetFolder.scala
+++ b/app/services/ProjectBackupAssetFolder.scala
@@ -395,6 +395,7 @@ class ProjectBackupAssetFolder @Inject()(config:Configuration, dbConfigProvider:
                         }
                       })
                   })
+                  Thread.sleep(config.getOptional[Long]("backup.pauseMilliseconds").getOrElse(0))
                 })
               } catch {
                 case e: java.lang.NullPointerException => logger.debug(s"Could not find any project files to process.")


### PR DESCRIPTION
## What does this change?

Adds an optional pause to the backup loop which is set in the configuration file. It takes the value of backup.pauseMilliseconds, which should be a number in milliseconds.

## How can we measure success?

The backup loop can now be set to pause between items.

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.