### PR TITLE
Send an E-mail if a Sensitive Project is Created

### DIFF
--- a/app/controllers/ProjectEntryController.scala
+++ b/app/controllers/ProjectEntryController.scala
@@ -371,8 +371,8 @@ class ProjectEntryController @Inject() (@Named("project-creation-actor") project
         sendToRabbitMq(CreateOperation(), projectEntry, rabbitMqPropagator)
         if (projectEntry.sensitive == Some(true)) {
           logger.info(s"Sensitive project created.")
-          val email = Email( config.get[String]("mail.subject"), s"${config.get[String]("mail.sender_name")} <${config.get[String]("mail.sender_address")}>", Seq(s"${config.get[String]("mail.recipient_name")} <${config.get[String]("mail.recipient_address")}>"), bodyText = Some(config.get[String]("mail.body")))
           try {
+            val email = Email( config.get[String]("mail.subject"), s"${config.get[String]("mail.sender_name")} <${config.get[String]("mail.sender_address")}>", Seq(s"${config.get[String]("mail.recipient_name")} <${config.get[String]("mail.recipient_address")}>"), bodyText = Some(s"A sensitive project has been created by ${projectEntry.user}. It has the identity number ${projectEntry.id.get} and the tile '${projectEntry.projectTitle}'"))
             mailerClient.send(email)
           } catch {
             case e: Exception => logger.error(s"Sending e-mail failed with error: $e")

--- a/app/controllers/ProjectEntryController.scala
+++ b/app/controllers/ProjectEntryController.scala
@@ -371,7 +371,7 @@ class ProjectEntryController @Inject() (@Named("project-creation-actor") project
         sendToRabbitMq(CreateOperation(), projectEntry, rabbitMqPropagator)
         if (projectEntry.sensitive == Some(true)) {
           logger.info(s"Sensitive project created.")
-          val email = Email( config.get[String]("mail.subject"), s"${config.get[String]("mail.sender_name")} FROM <${config.get[String]("mail.sender_address")}>", Seq(s"${config.get[String]("mail.recipient_name")} TO <${config.get[String]("mail.recipient_address")}>"), bodyText = Some(config.get[String]("mail.body")))
+          val email = Email( config.get[String]("mail.subject"), s"${config.get[String]("mail.sender_name")} <${config.get[String]("mail.sender_address")}>", Seq(s"${config.get[String]("mail.recipient_name")} <${config.get[String]("mail.recipient_address")}>"), bodyText = Some(config.get[String]("mail.body")))
           try {
             mailerClient.send(email)
           } catch {

--- a/app/controllers/ProjectEntryController.scala
+++ b/app/controllers/ProjectEntryController.scala
@@ -372,7 +372,7 @@ class ProjectEntryController @Inject() (@Named("project-creation-actor") project
         if (projectEntry.sensitive == Some(true)) {
           logger.info(s"Sensitive project created.")
           try {
-            val email = Email( config.get[String]("mail.subject"), s"${config.get[String]("mail.sender_name")} <${config.get[String]("mail.sender_address")}>", Seq(s"${config.get[String]("mail.recipient_name")} <${config.get[String]("mail.recipient_address")}>"), bodyText = Some(s"A sensitive project has been created by ${projectEntry.user}. It has the identity number ${projectEntry.id.get} and the tile '${projectEntry.projectTitle}'"))
+            val email = Email( config.get[String]("mail.subject"), s"${config.get[String]("mail.sender_name")} <${config.get[String]("mail.sender_address")}>", Seq(s"${config.get[String]("mail.recipient_name")} <${config.get[String]("mail.recipient_address")}>"), bodyText = Some(s"A sensitive project has been created by ${projectEntry.user}. It has the identity number ${projectEntry.id.get} and the tile '${projectEntry.projectTitle}'."))
             mailerClient.send(email)
           } catch {
             case e: Exception => logger.error(s"Sending e-mail failed with error: $e")

--- a/build.sbt
+++ b/build.sbt
@@ -128,6 +128,9 @@ libraryDependencies ++= Seq(
   "software.amazon.awssdk" % "url-connection-client" % awsSdk2Version
 )
 
+libraryDependencies += "com.typesafe.play" %% "play-mailer" % "8.0.1"
+libraryDependencies += "com.typesafe.play" %% "play-mailer-guice" % "8.0.1"
+
 enablePlugins(UniversalPlugin)
 
 enablePlugins(LinuxPlugin)


### PR DESCRIPTION
## What does this change?

Causes an e-mail to be sent if a sensitive project is created. Requires data similar to the following be added to the pluto-core configuration file to work as intended: -

    play.mailer {
      host = "smtp.a.org"
      port = 25
      ssl = no
      tls = no
      tlsRequired = no
      user = null
      password = null
      debug = no
      timeout = null
      connectiontimeout = null
      mock = no
      props {
      }
    }

    mail {
      subject = "String"
      sender_name = "String"
      sender_address = "a@a.org"
      recipient_name = "String"
      recipient_address = "b@b.org"
    }

## How can we measure success?

The e-mail is sent.

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.