### PR TITLE
Allow Users to Restore Premiere Pro and After Effects Project Files

### DIFF
--- a/app/controllers/ProjectEntryController.scala
+++ b/app/controllers/ProjectEntryController.scala
@@ -1147,7 +1147,7 @@ class ProjectEntryController @Inject() (@Named("project-creation-actor") project
     })
   }}
 
-  def restoreBackup(requestedId: Int, requestedVersion: Int) = IsAdminAsync {uid=>{request=>
+  def restoreBackup(requestedId: Int, requestedVersion: Int) = IsAuthenticatedAsync {uid=>{request=>
     implicit val db = dbConfig.db
 
     selectid(requestedId).flatMap({

--- a/frontend/app/ProjectEntryList/BackupEntry.tsx
+++ b/frontend/app/ProjectEntryList/BackupEntry.tsx
@@ -28,7 +28,6 @@ interface BackupEntryProps {
   filepath: string;
   version: number;
   premiereVersion?: number;
-  isAdmin: boolean;
   projectId?: number;
 }
 
@@ -124,48 +123,46 @@ const BackupEntry: React.FC<BackupEntryProps> = (props) => {
           )}
         </>
       </ListItemText>
-      {props.isAdmin ? (
-        <div>
-          <Button
-            color="secondary"
-            variant="contained"
-            onClick={handleClickOpenDialog}
-          >
-            Restore
-          </Button>
-          {/* Confirmation Dialog */}
-          <Dialog
-            open={openDialog}
-            onClose={handleCloseDialog}
-            aria-labelledby="update-file-dialog-title"
-            aria-describedby="update-file-dialog-description"
-          >
-            <DialogTitle id="update-file-dialog-title">
-              Confirm Project File Restore
-            </DialogTitle>
-            <DialogContent>
-              <DialogContentText id="update-file-dialog-description">
-                <strong>
-                  Are you sure you want to restore the project file?
-                </strong>
-                <br />
-                You are about to restore a backed up project file. This action
-                will overwrite the current file.
-                <br />
-                <br />
-              </DialogContentText>
-            </DialogContent>
-            <DialogActions>
-              <Button onClick={handleCloseDialog} color="primary">
-                Cancel
-              </Button>
-              <Button onClick={handleConfirmUpload} color="primary" autoFocus>
-                Proceed
-              </Button>
-            </DialogActions>
-          </Dialog>
-        </div>
-      ) : null}
+      <div>
+        <Button
+          color="secondary"
+          variant="contained"
+          onClick={handleClickOpenDialog}
+        >
+          Restore
+        </Button>
+        {/* Confirmation Dialog */}
+        <Dialog
+          open={openDialog}
+          onClose={handleCloseDialog}
+          aria-labelledby="update-file-dialog-title"
+          aria-describedby="update-file-dialog-description"
+        >
+          <DialogTitle id="update-file-dialog-title">
+            Confirm Project File Restore
+          </DialogTitle>
+          <DialogContent>
+            <DialogContentText id="update-file-dialog-description">
+              <strong>
+                Are you sure you want to restore the project file?
+              </strong>
+              <br />
+              You are about to restore a backed up project file. This action
+              will overwrite the current file.
+              <br />
+              <br />
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={handleCloseDialog} color="primary">
+              Cancel
+            </Button>
+            <Button onClick={handleConfirmUpload} color="primary" autoFocus>
+              Proceed
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </div>
     </ListItem>
   );
 };

--- a/frontend/app/ProjectEntryList/ProjectBackups.tsx
+++ b/frontend/app/ProjectEntryList/ProjectBackups.tsx
@@ -117,7 +117,6 @@ const ProjectBackups: React.FC<RouteComponentProps<{ itemid: string }>> = (
   const [dialogErrString, setDialogErrString] = useState<string | undefined>(
     undefined
   );
-  const [isAdmin, setIsAdmin] = useState<boolean>(false);
   const [primaryFiles, setPrimaryFiles] = useState<FileEntry[]>([]);
   const [backupFiles, setBackupFiles] = useState<FileEntry[]>([]);
   const [primaryFileMetadata, setPrimaryFileMetadata] = useState<
@@ -168,19 +167,6 @@ const ProjectBackups: React.FC<RouteComponentProps<{ itemid: string }>> = (
       });
     }
   }, [project]);
-
-  const fetchWhoIsLoggedIn = async () => {
-    try {
-      const loggedIn = await isLoggedIn();
-      setIsAdmin(loggedIn.isAdmin);
-    } catch {
-      setIsAdmin(false);
-    }
-  };
-
-  useEffect(() => {
-    fetchWhoIsLoggedIn();
-  }, []);
 
   return (
     <>
@@ -243,7 +229,6 @@ const ProjectBackups: React.FC<RouteComponentProps<{ itemid: string }>> = (
                 filepath={f.filepath}
                 version={f.version}
                 premiereVersion={f.premiereVersion}
-                isAdmin={isAdmin}
                 projectId={project?.id}
               />
             ))}


### PR DESCRIPTION
## What does this change?

Allows users to restore back ups of Premiere Pro and After Effect projects files.

## How can we measure success?

Users can restore the files.

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.