### PR TITLE
Restore Cubase and Audition Project Files

### DIFF
--- a/app/controllers/ProjectEntryController.scala
+++ b/app/controllers/ProjectEntryController.scala
@@ -1228,6 +1228,7 @@ class ProjectEntryController @Inject() (@Named("project-creation-actor") project
                 val splitterRegex = "^(?:[^\\/]*\\/){4}".r
                 val filenameRegex = "([^\\/]+$)".r
                 fileEntryData.map(fileData => {
+                  Thread.sleep(4000)
                   new File(s"${config.get[String]("postrun.assetFolder.basePath")}/${splitterRegex.findFirstIn(fileData.filepath).get}RestoredProjectFiles/${filenameRegex.replaceFirstIn(splitterRegex.replaceFirstIn(fileData.filepath,""),"")}").mkdirs()
                   val timestamp = dateTimeToTimestamp(ZonedDateTime.now())
                   if (new File(s"${config.get[String]("postrun.assetFolder.basePath")}/${splitterRegex.findFirstIn(fileData.filepath).get}RestoredProjectFiles/${splitterRegex.replaceFirstIn(fileData.filepath,"")}").exists()) {

--- a/app/controllers/ProjectEntryController.scala
+++ b/app/controllers/ProjectEntryController.scala
@@ -1228,7 +1228,7 @@ class ProjectEntryController @Inject() (@Named("project-creation-actor") project
                 val splitterRegex = "^(?:[^\\/]*\\/){4}".r
                 val filenameRegex = "([^\\/]+$)".r
                 fileEntryData.map(fileData => {
-                  Thread.sleep(4000)
+                  Thread.sleep(100)
                   new File(s"${config.get[String]("postrun.assetFolder.basePath")}/${splitterRegex.findFirstIn(fileData.filepath).get}RestoredProjectFiles/${filenameRegex.replaceFirstIn(splitterRegex.replaceFirstIn(fileData.filepath,""),"")}").mkdirs()
                   val timestamp = dateTimeToTimestamp(ZonedDateTime.now())
                   if (new File(s"${config.get[String]("postrun.assetFolder.basePath")}/${splitterRegex.findFirstIn(fileData.filepath).get}RestoredProjectFiles/${splitterRegex.replaceFirstIn(fileData.filepath,"")}").exists()) {

--- a/conf/routes
+++ b/conf/routes
@@ -69,6 +69,7 @@ GET     /api/project/:id/missingFiles       @controllers.MissingFilesController.
 GET     /api/project/:id/removeWarning      @controllers.MissingFilesController.removeWarning(id:Int)
 GET     /api/project/:id/fileDownload       @controllers.ProjectEntryController.fileDownload(id:Int)
 PUT     /api/project/:id/restore/:version   @controllers.ProjectEntryController.restoreBackup(id:Int, version:Int)
+PUT     /api/project/:id/restoreForAssetFolder  @controllers.ProjectEntryController.restoreAssetFolderBackup(id:Int)
 
 GET     /api/valid-users                    @controllers.ProjectEntryController.queryUsersForAutocomplete(prefix:String ?= "", limit:Option[Int])
 GET     /api/known-user                     @controllers.ProjectEntryController.isUserKnown(uname:String ?= "")

--- a/frontend/app/ProjectEntryList/AssetFolderProjectBackups.tsx
+++ b/frontend/app/ProjectEntryList/AssetFolderProjectBackups.tsx
@@ -83,7 +83,7 @@ const AssetFolderProjectBackups: React.FC<RouteComponentProps<{
   const handleRestore = async () => {
     try {
       const request =
-          "/api/project/" + props.match.params.itemid + "/restoreForAssetFolder";
+        "/api/project/" + props.match.params.itemid + "/restoreForAssetFolder";
       const response = await axios.put(request, null, {
         headers: {
           "Content-Type": "application/json",
@@ -91,14 +91,14 @@ const AssetFolderProjectBackups: React.FC<RouteComponentProps<{
       });
       console.log(response.data);
       SystemNotification.open(
-          SystemNotifcationKind.Success,
-          `${response.data.detail}`
+        SystemNotifcationKind.Success,
+        `${response.data.detail}`
       );
     } catch (error) {
       console.error("Error restoring file:", error);
       SystemNotification.open(
-          SystemNotifcationKind.Error,
-          `Failed to restore project: ${error}`
+        SystemNotifcationKind.Error,
+        `Failed to restore project: ${error}`
       );
     }
   };
@@ -125,25 +125,31 @@ const AssetFolderProjectBackups: React.FC<RouteComponentProps<{
         </Grid>
         <Grid item>
           <Button
-              color="secondary"
-              variant="contained"
-              onClick={handleClickOpenDialog}
+            color="secondary"
+            variant="contained"
+            onClick={handleClickOpenDialog}
           >
             Restore
           </Button>
           {/* Confirmation Dialog */}
           <Dialog
-              open={openDialog}
-              onClose={handleCloseDialog}
-              aria-labelledby="update-file-dialog-title"
-              aria-describedby="update-file-dialog-description"
+            open={openDialog}
+            onClose={handleCloseDialog}
+            aria-labelledby="update-file-dialog-title"
+            aria-describedby="update-file-dialog-description"
           >
             <DialogTitle id="update-file-dialog-title">
               Confirm Restoration of Backed up Project Files:
             </DialogTitle>
             <DialogContent>
               <DialogContentText id="update-file-dialog-description">
-                You are about to restore all the backed up project files shown on this page. This will result in a folder being created in the project's asset folder named "RestoredProjectFiles", and within that a list of all Cubase/Audition files we have backed up. Once you have identified which project file you need, please move it out of this folder and into the root of project’s asset folder, before you carry on working with it.
+                You are about to restore all the backed up project files shown
+                on this page. This will result in a folder being created in the
+                project's asset folder named "RestoredProjectFiles", and within
+                that a list of all Cubase/Audition files we have backed up. Once
+                you have identified which project file you need, please move it
+                out of this folder and into the root of project’s asset folder,
+                before you carry on working with it.
                 <br />
                 <br />
               </DialogContentText>


### PR DESCRIPTION
## What does this change?

Allows users to restore Cubase and Audition project files. If the 'Restore' button is pressed a folder called 'RestoredProjectFiles' should get created in the project's asset folder containing all of the backup project files.

## How can we measure success?

The folder gets created successfully.

## Images

![Screenshot 2025-05-08 at 12 00 29](https://github.com/user-attachments/assets/51e8240d-e93a-4f2a-af32-50ab498803fe)

![Screenshot 2025-05-08 at 12 01 39](https://github.com/user-attachments/assets/3b7d7cc6-2137-4af2-b7ba-89d995796466)

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.