### PR TITLE
Extra Text and Buttons

### DIFF
--- a/frontend/app/CommissionsList/CommissionDeleteDataComponent.tsx
+++ b/frontend/app/CommissionsList/CommissionDeleteDataComponent.tsx
@@ -381,7 +381,10 @@ const CommissionDeleteDataComponent: React.FC<CommissionDeleteDataComponentProps
                     <br />
                     1. If you have 'Project Records' enabled it will break
                     deletion from Vidispine, the Storage Area Network, and the
-                    Object Matrix system.
+                    Object Matrix system. If you need to delete the project
+                    records, it is best to come back about a week after the
+                    first delete attempt was made to give the system time to
+                    delete other data.
                     <br />
                     <br />
                     2. Some parts of the Pluto system where not designed to be
@@ -433,6 +436,15 @@ const CommissionDeleteDataComponent: React.FC<CommissionDeleteDataComponentProps
                       onClick={() => history.goBack()}
                     >
                       Back
+                    </Button>
+                    <Button
+                      className="cancel"
+                      variant="outlined"
+                      onClick={() =>
+                        window.location.assign(`/pluto-core/deleted/`)
+                      }
+                    >
+                      Deletion Records
                     </Button>
                     <Button type="submit" variant="contained" color="secondary">
                       Submit Delete Request

--- a/frontend/app/ProjectEntryList/ProjectDeleteDataComponent.tsx
+++ b/frontend/app/ProjectEntryList/ProjectDeleteDataComponent.tsx
@@ -320,7 +320,9 @@ const ProjectDeleteDataComponent: React.FC<ProjectDeleteDataComponentProps> = (
                 <br />
                 1. If you have 'Project Record' enabled it will break deletion
                 from Vidispine, the Storage Area Network, and the Object Matrix
-                system.
+                system. If you need to delete the project record, it is best to
+                come back about a week after the first delete attempt was made
+                to give the system time to delete other data.
                 <br />
                 <br />
                 2. Some parts of the Pluto system where not designed to be
@@ -367,6 +369,13 @@ const ProjectDeleteDataComponent: React.FC<ProjectDeleteDataComponentProps> = (
                   onClick={() => history.goBack()}
                 >
                   Back
+                </Button>
+                <Button
+                  className="cancel"
+                  variant="outlined"
+                  onClick={() => window.location.assign(`/pluto-core/deleted/`)}
+                >
+                  Deletion Records
                 </Button>
                 <Tooltip title="See project's media">
                   <IconButton


### PR DESCRIPTION
## What does this change?

Adds some extra text and buttons which link to the deletion records page to deletion pages.

## How can we measure success?

The text displays and the buttons work.

## Images

![Screenshot 2025-06-04 at 12 16 16](https://github.com/user-attachments/assets/d60758cb-c058-4fd5-9ebf-62278272047d)

![Screenshot 2025-06-04 at 12 16 54](https://github.com/user-attachments/assets/49783f76-77a9-4556-b415-0c1aced46bdf)

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.